### PR TITLE
Add more verbose error message to cluster package

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -157,7 +157,7 @@ func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMs
 	}
 	for contentID, err := range remoteOutput.Errors {
 		if err != nil {
-			gplog.Verbose("%s on segment %d on host %s with error %s", messageFunc(contentID), contentID, cluster.GetHostForContent(contentID), err)
+			gplog.Verbose("%s on segment %d on host %s with error %s: %s", messageFunc(contentID), contentID, cluster.GetHostForContent(contentID), err, remoteOutput.Stderrs[contentID])
 		}
 	}
 	if len(noFatal) == 1 && noFatal[0] == true {


### PR DESCRIPTION
Previously, when a remote command failed, in many cases the user would
simply see an error code in the log. Now, we log the stderr output
associated with the failed command.

Previous output:
`Unable to clean up segment data pipe on segment 1 on host myhostname with error exit status 1`

New output:
`Unable to clean up segment data pipe on segment 1 on host myhostname with error exit status 1: rm: /tmp/op: No such file or directory`

Authored-by: Chris Hajas <chajas@pivotal.io>