### PR TITLE
Enable executing remote commands on a per-host basis

### DIFF
--- a/testhelper/structs.go
+++ b/testhelper/structs.go
@@ -53,7 +53,7 @@ func (executor *TestExecutor) ExecuteLocalCommand(commandStr string) (string, er
 	return "", nil
 }
 
-func (executor *TestExecutor) ExecuteClusterCommand(commandMap map[int][]string) *cluster.RemoteOutput {
+func (executor *TestExecutor) ExecuteClusterCommand(scope int, commandMap map[int][]string) *cluster.RemoteOutput {
 	executor.NumExecutions++
 	executor.ClusterCommands = append(executor.ClusterCommands, commandMap)
 	if executor.ErrorOnExecNum == 0 || executor.NumExecutions == executor.ErrorOnExecNum {


### PR DESCRIPTION
Previously, the remote shell execution functions in the cluster package could
only execute shell commands on a per-segment basis.  This commit adds the
capability to execute them on a per-host basis.  As with the per-segment
functions, it is possible to specify whether to include or exclude the master
in the list of hosts on which to execute the function.

To avoid copy-pasting or drastically modifying the generic functions for command
execution and error handling, the new GenerateSSHCommandMapForHosts function
still generates maps from ints (content IDs) to slices of strings (the commands
and their arguments) to be used with ExecuteClusterCommand; however, the error
messages for such function calls are appropriate for the per-host behavior and
don't mention segments at all to aid in debugging.

---

This PR introduces a breaking change for any utility calling GenerateAndExecuteCommand, so those utilities will have to be updated accordingly.  I've already made those changes locally for gpbackup and gprestore, and will be committing those after this PR is merged.