### PR TITLE
Log command being run when a cluster command fails

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -205,7 +205,8 @@ func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMs
 			if remoteOutput.Scope != ON_HOSTS {
 				segMsg = fmt.Sprintf("on segment %d ", contentID)
 			}
-			gplog.Verbose("%s %son host %s with error %s: %s Command was: %s", messageFunc(contentID), segMsg, cluster.GetHostForContent(contentID), err, remoteOutput.Stderrs[contentID], remoteOutput.CmdStrs[contentID])
+			gplog.Verbose("%s %son host %s with error %s: %s", messageFunc(contentID), segMsg, cluster.GetHostForContent(contentID), err, remoteOutput.Stderrs[contentID])
+			gplog.Verbose("Command was: %s", remoteOutput.CmdStrs[contentID])
 		}
 	}
 	if len(noFatal) == 1 && noFatal[0] == true {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -59,6 +59,7 @@ type RemoteOutput struct {
 	Stdouts   map[int]string
 	Stderrs   map[int]string
 	Errors    map[int]error
+	CmdStrs   map[int]string
 }
 
 /*
@@ -126,7 +127,8 @@ func newRemoteOutput(scope int, numIDs int) *RemoteOutput {
 	stdout := make(map[int]string, numIDs)
 	stderr := make(map[int]string, numIDs)
 	err := make(map[int]error, numIDs)
-	return &RemoteOutput{Scope: scope, NumErrors: 0, Stdouts: stdout, Stderrs: stderr, Errors: err}
+	cmdStr := make(map[int]string, numIDs)
+	return &RemoteOutput{Scope: scope, NumErrors: 0, Stdouts: stdout, Stderrs: stderr, Errors: err, CmdStrs: cmdStr}
 }
 
 func (executor *GPDBExecutor) ExecuteClusterCommand(scope int, commandMap map[int][]string) *RemoteOutput {
@@ -160,6 +162,7 @@ func (executor *GPDBExecutor) ExecuteClusterCommand(scope int, commandMap map[in
 		output.Stdouts[id] = stdouts[index]
 		output.Stderrs[id] = stderrs[index]
 		output.Errors[id] = errors[index]
+		output.CmdStrs[id] = strings.Join(commandMap[id], " ")
 		if output.Errors[id] != nil {
 			output.NumErrors++
 		}
@@ -202,7 +205,7 @@ func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMs
 			if remoteOutput.Scope != ON_HOSTS {
 				segMsg = fmt.Sprintf("on segment %d ", contentID)
 			}
-			gplog.Verbose("%s %son host %s with error %s: %s", messageFunc(contentID), segMsg, cluster.GetHostForContent(contentID), err, remoteOutput.Stderrs[contentID])
+			gplog.Verbose("%s %son host %s with error %s: %s Command was: %s", messageFunc(contentID), segMsg, cluster.GetHostForContent(contentID), err, remoteOutput.Stderrs[contentID], remoteOutput.CmdStrs[contentID])
 		}
 	}
 	if len(noFatal) == 1 && noFatal[0] == true {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -313,9 +313,12 @@ var _ = Describe("cluster/cluster tests", func() {
 				Errors: map[int]error{
 					1: errors.Errorf("ssh error"),
 				},
+				CmdStrs: map[int]string{
+					1: "this is the command",
+				},
 			}
 			defer testhelper.ShouldPanicWithMessage("Got an error on 1 segment. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error received on segment 1 on host remotehost1 with error ssh error: exit status 1`))
+			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error received on segment 1 on host remotehost1 with error ssh error: exit status 1 Command was: this is the command`))
 			testCluster.CheckClusterError(remoteOutput, "Got an error", func(contentID int) string {
 				return "Error received"
 			})

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -318,7 +318,8 @@ var _ = Describe("cluster/cluster tests", func() {
 				},
 			}
 			defer testhelper.ShouldPanicWithMessage("Got an error on 1 segment. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error received on segment 1 on host remotehost1 with error ssh error: exit status 1 Command was: this is the command`))
+			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Command was: this is the command`))
+			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error received on segment 1 on host remotehost1 with error ssh error: exit status 1`))
 			testCluster.CheckClusterError(remoteOutput, "Got an error", func(contentID int) string {
 				return "Error received"
 			})


### PR DESCRIPTION
Previously, we logged the return value and output of the command, but
the actual bash command being run is helpful to reproduce the issue.

This changes the output from 
```
20180322:17:15:00 gpbackup:pivotal:melville:012578-[DEBUG]:-Unable to create segment data pipe on segment 0 on host localhost with error exit status 127: bash: mkfiffo: command not found
```
to
```
20180322:17:15:00 gpbackup:pivotal:melville:012578-[DEBUG]:-Unable to create segment data pipe on segment 0 on host localhost with error exit status 127: bash: mkfiffo: command not found
 Command was: ssh -o StrictHostKeyChecking=no user@localhost mkfiffo /Users/user/workspace/gpdb/gpAux/gpdemo/datadirs/dbfast1/demoDataDir0/gpbackup_0_20180322171500_pipe
```

Authored-by: Chris Hajas <chajas@pivotal.io>