### PR TITLE
Allow Begin()ing a transaction on each connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+vendor

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -131,6 +131,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9b48cdf280444383e8c5c9936d12ad65a8970fda7d9d77ac974c91c167d27307"
+  inputs-digest = "a44e31fc3cf6e00873ef130ca4c23509a79426ba53c2632e074238d28925cc69"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/dbconn/dbconn_test.go
+++ b/dbconn/dbconn_test.go
@@ -75,12 +75,14 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			Expect(connection.DBName).To(Equal("testdb"))
 			Expect(connection.NumConns).To(Equal(1))
 			Expect(len(connection.ConnPool)).To(Equal(1))
+			Expect(len(connection.Tx)).To(Equal(1))
 		})
 		It("makes multiple connections successfully if the database exists", func() {
 			connection.MustConnect(3)
 			Expect(connection.DBName).To(Equal("testdb"))
 			Expect(connection.NumConns).To(Equal(3))
 			Expect(len(connection.ConnPool)).To(Equal(3))
+			Expect(len(connection.Tx)).To(Equal(3))
 		})
 		It("does not connect if the database exists but the connection is refused", func() {
 			connection.Driver = testhelper.TestDriver{ErrToReturn: fmt.Errorf("pq: connection refused"), DB: mockdb, User: "testrole"}
@@ -128,18 +130,22 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			connection.MustConnect(3)
 			Expect(connection.NumConns).To(Equal(3))
 			Expect(len(connection.ConnPool)).To(Equal(3))
+			Expect(len(connection.Tx)).To(Equal(3))
 			connection.Close()
 			Expect(connection.NumConns).To(Equal(0))
 			Expect(connection.ConnPool).To(BeNil())
+			Expect(connection.Tx).To(BeNil())
 		})
 		It("does nothing if there are no open connections", func() {
 			connection.MustConnect(3)
 			connection.Close()
 			Expect(connection.NumConns).To(Equal(0))
 			Expect(connection.ConnPool).To(BeNil())
+			Expect(connection.Tx).To(BeNil())
 			connection.Close()
 			Expect(connection.NumConns).To(Equal(0))
 			Expect(connection.ConnPool).To(BeNil())
+			Expect(connection.Tx).To(BeNil())
 		})
 	})
 	Describe("DBConn.Exec", func() {


### PR DESCRIPTION
We have a feature which requests creating and inserting tables in
parallel with multiple connections.

This commit allows rolling back a single transaction if errors happen.