### PR TITLE
New a DB connection with database, username, host and port

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -131,6 +131,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a44e31fc3cf6e00873ef130ca4c23509a79426ba53c2632e074238d28925cc69"
+  inputs-digest = "9b48cdf280444383e8c5c9936d12ad65a8970fda7d9d77ac974c91c167d27307"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -124,6 +124,7 @@ func (dbconn *DBConn) Close() {
 			}
 		}
 		dbconn.ConnPool = nil
+		dbconn.Tx = nil
 		dbconn.NumConns = 0
 	}
 }

--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -65,7 +65,7 @@ func (driver GPDBDriver) Connect(driverName string, dataSourceName string) (*sql
  * Database functions
  */
 
-func NewDBConn(dbname string) *DBConn {
+func NewDBConnFromEnvironment(dbname string) *DBConn {
 	if dbname == "" {
 		gplog.Fatal(errors.New("No database provided"), "")
 	}
@@ -82,6 +82,22 @@ func NewDBConn(dbname string) *DBConn {
 	port, err := strconv.Atoi(operating.System.Getenv("PGPORT"))
 	if err != nil {
 		port = 5432
+	}
+
+	return NewDBConn(dbname, username, host, port)
+}
+
+func NewDBConn(dbname, username, host string, port int) *DBConn {
+	if dbname == "" {
+		gplog.Fatal(errors.New("No database provided"), "")
+	}
+
+	if username == "" {
+		gplog.Fatal(errors.New("No username provided"), "")
+	}
+
+	if host == "" {
+		gplog.Fatal(errors.New("No host provided"), "")
 	}
 
 	return &DBConn{

--- a/dbconn/dbconn_test.go
+++ b/dbconn/dbconn_test.go
@@ -274,7 +274,7 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			mock.ExpectCommit()
 			connection.MustBegin()
 			connection.MustCommit()
-			Expect(connection.Tx).To(BeNil())
+			Expect(connection.Tx[0]).To(BeNil())
 		})
 		It("panics if it executes a COMMIT outside a transaction", func() {
 			defer testhelper.ShouldPanicWithMessage("Cannot commit transaction; there is no transaction in progress")

--- a/testhelper/functions.go
+++ b/testhelper/functions.go
@@ -52,7 +52,7 @@ func SetDBVersion(connection *dbconn.DBConn, versionStr string) {
 func CreateAndConnectMockDB(numConns int) (*dbconn.DBConn, sqlmock.Sqlmock) {
 	mockdb, mock := CreateMockDB()
 	driver := TestDriver{DB: mockdb, DBName: "testdb", User: "testrole"}
-	connection := dbconn.NewDBConn("testdb")
+	connection := dbconn.NewDBConnFromEnvironment("testdb")
 	connection.Driver = driver
 	connection.MustConnect(numConns)
 	SetDBVersion(connection, "5.1.0")


### PR DESCRIPTION
New a DB connection with detailed arguments, so we could connect to
different clusters, the former one is name "NewDBConnFromEnvironment"
now.