### PR TITLE
Add GetWithArgs and SelectWithArgs method to dbconn

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -243,12 +243,28 @@ func (dbconn *DBConn) MustExec(query string, whichConn ...int) {
 	gplog.FatalOnError(err)
 }
 
+func (dbconn *DBConn) GetWithArgs(destination interface{}, query string, args ...interface{}) error {
+	connNum := 0
+	if dbconn.Tx[connNum] != nil {
+		return dbconn.Tx[connNum].Get(destination, query, args)
+	}
+	return dbconn.ConnPool[connNum].Get(destination, query, args)
+}
+
 func (dbconn *DBConn) Get(destination interface{}, query string, whichConn ...int) error {
 	connNum := dbconn.ValidateConnNum(whichConn...)
 	if dbconn.Tx[connNum] != nil {
 		return dbconn.Tx[connNum].Get(destination, query)
 	}
 	return dbconn.ConnPool[connNum].Get(destination, query)
+}
+
+func (dbconn *DBConn) SelectWithArgs(destination interface{}, query string, args ...interface{}) error {
+	connNum := 0
+	if dbconn.Tx[connNum] != nil {
+		return dbconn.Tx[connNum].Select(destination, query, args)
+	}
+	return dbconn.ConnPool[connNum].Select(destination, query, args)
 }
 
 func (dbconn *DBConn) Select(destination interface{}, query string, whichConn ...int) error {


### PR DESCRIPTION
Passing query argument is supported in lib/pq like this

q:= `SELECT a from t WHERE b = $1`
db.Query(q, arg1)

Add query argument support for Get and Select.
Only one varadic parameter is allowed for function, the whichConn
parameters is hardcoded to 0.