### PR TITLE
Add GetWithArgs and SelectWithArgs method to dbconn

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -244,11 +244,10 @@ func (dbconn *DBConn) MustExec(query string, whichConn ...int) {
 }
 
 func (dbconn *DBConn) GetWithArgs(destination interface{}, query string, args ...interface{}) error {
-	connNum := 0
-	if dbconn.Tx[connNum] != nil {
-		return dbconn.Tx[connNum].Get(destination, query, args...)
+	if dbconn.Tx[0] != nil {
+		return dbconn.Tx[0].Get(destination, query, args...)
 	}
-	return dbconn.ConnPool[connNum].Get(destination, query, args...)
+	return dbconn.ConnPool[0].Get(destination, query, args...)
 }
 
 func (dbconn *DBConn) Get(destination interface{}, query string, whichConn ...int) error {
@@ -260,11 +259,10 @@ func (dbconn *DBConn) Get(destination interface{}, query string, whichConn ...in
 }
 
 func (dbconn *DBConn) SelectWithArgs(destination interface{}, query string, args ...interface{}) error {
-	connNum := 0
-	if dbconn.Tx[connNum] != nil {
-		return dbconn.Tx[connNum].Select(destination, query, args...)
+	if dbconn.Tx[0] != nil {
+		return dbconn.Tx[0].Select(destination, query, args...)
 	}
-	return dbconn.ConnPool[connNum].Select(destination, query, args...)
+	return dbconn.ConnPool[0].Select(destination, query, args...)
 }
 
 func (dbconn *DBConn) Select(destination interface{}, query string, whichConn ...int) error {

--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -243,12 +243,28 @@ func (dbconn *DBConn) MustExec(query string, whichConn ...int) {
 	gplog.FatalOnError(err)
 }
 
+func (dbconn *DBConn) GetWithArgs(destination interface{}, query string, args ...interface{}) error {
+	connNum := 0
+	if dbconn.Tx[connNum] != nil {
+		return dbconn.Tx[connNum].Get(destination, query, args...)
+	}
+	return dbconn.ConnPool[connNum].Get(destination, query, args...)
+}
+
 func (dbconn *DBConn) Get(destination interface{}, query string, whichConn ...int) error {
 	connNum := dbconn.ValidateConnNum(whichConn...)
 	if dbconn.Tx[connNum] != nil {
 		return dbconn.Tx[connNum].Get(destination, query)
 	}
 	return dbconn.ConnPool[connNum].Get(destination, query)
+}
+
+func (dbconn *DBConn) SelectWithArgs(destination interface{}, query string, args ...interface{}) error {
+	connNum := 0
+	if dbconn.Tx[connNum] != nil {
+		return dbconn.Tx[connNum].Select(destination, query, args...)
+	}
+	return dbconn.ConnPool[connNum].Select(destination, query, args...)
 }
 
 func (dbconn *DBConn) Select(destination interface{}, query string, whichConn ...int) error {

--- a/dbconn/dbconn_test.go
+++ b/dbconn/dbconn_test.go
@@ -205,8 +205,8 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			Expect(testRecord.Tablename).To(Equal("table1"))
 		})
 		It("executes a GET with argument outside of a transaction", func() {
-			arg1 := "1"
-			arg2 := 2
+			arg1 := "table1"
+			arg2 := "table2"
 			two_col_single_row := sqlmock.NewRows([]string{"schemaname", "tablename"}).
 				AddRow("schema1", "table1")
 			mock.ExpectQuery("SELECT (.*)").WithArgs(arg1, arg2).WillReturnRows(two_col_single_row)
@@ -216,7 +216,7 @@ var _ = Describe("dbconn/dbconn tests", func() {
 				Tablename  string
 			}{}
 
-			err := connection.GetWithArgs(&testRecord, "SELECT schemaname, tablename FROM two_columns ORDER BY schemaname", arg1, arg2)
+			err := connection.GetWithArgs(&testRecord, "SELECT schemaname, tablename FROM two_columns WHERE tablename=$1 OR tablename=$2", arg1, arg2)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testRecord.Schemaname).To(Equal("schema1"))
 			Expect(testRecord.Tablename).To(Equal("table1"))
@@ -263,8 +263,8 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			Expect(testSlice[1].Tablename).To(Equal("table2"))
 		})
 		It("executes a SELECT with argument outside of a transaction", func() {
-			arg1 := "1"
-			arg2 := 2
+			arg1 := "table1"
+			arg2 := "table2"
 			two_col_rows := sqlmock.NewRows([]string{"schemaname", "tablename"}).
 				AddRow("schema1", "table1").
 				AddRow("schema2", "table2")
@@ -275,7 +275,7 @@ var _ = Describe("dbconn/dbconn tests", func() {
 				Tablename  string
 			}, 0)
 
-			err := connection.SelectWithArgs(&testSlice, "SELECT schemaname, tablename FROM two_columns ORDER BY schemaname LIMIT 2", arg1, arg2)
+			err := connection.SelectWithArgs(&testSlice, "SELECT schemaname, tablename FROM two_columns WHERE tablename=$1 OR tablename=$2", arg1, arg2)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(testSlice)).To(Equal(2))

--- a/dbconn/dbconn_test.go
+++ b/dbconn/dbconn_test.go
@@ -204,6 +204,23 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			Expect(testRecord.Schemaname).To(Equal("schema1"))
 			Expect(testRecord.Tablename).To(Equal("table1"))
 		})
+		It("executes a GET with argument outside of a transaction", func() {
+			arg1 := "1"
+			arg2 := 2
+			two_col_single_row := sqlmock.NewRows([]string{"schemaname", "tablename"}).
+				AddRow("schema1", "table1")
+			mock.ExpectQuery("SELECT (.*)").WithArgs(arg1, arg2).WillReturnRows(two_col_single_row)
+
+			testRecord := struct {
+				Schemaname string
+				Tablename  string
+			}{}
+
+			err := connection.GetWithArgs(&testRecord, "SELECT schemaname, tablename FROM two_columns ORDER BY schemaname", arg1, arg2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(testRecord.Schemaname).To(Equal("schema1"))
+			Expect(testRecord.Tablename).To(Equal("table1"))
+		})
 		It("executes a GET in a transaction", func() {
 			two_col_single_row := sqlmock.NewRows([]string{"schemaname", "tablename"}).
 				AddRow("schema1", "table1")
@@ -237,6 +254,28 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			}, 0)
 
 			err := connection.Select(&testSlice, "SELECT schemaname, tablename FROM two_columns ORDER BY schemaname LIMIT 2")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(testSlice)).To(Equal(2))
+			Expect(testSlice[0].Schemaname).To(Equal("schema1"))
+			Expect(testSlice[0].Tablename).To(Equal("table1"))
+			Expect(testSlice[1].Schemaname).To(Equal("schema2"))
+			Expect(testSlice[1].Tablename).To(Equal("table2"))
+		})
+		It("executes a SELECT with argument outside of a transaction", func() {
+			arg1 := "1"
+			arg2 := 2
+			two_col_rows := sqlmock.NewRows([]string{"schemaname", "tablename"}).
+				AddRow("schema1", "table1").
+				AddRow("schema2", "table2")
+			mock.ExpectQuery("SELECT (.*)").WithArgs(arg1, arg2).WillReturnRows(two_col_rows)
+
+			testSlice := make([]struct {
+				Schemaname string
+				Tablename  string
+			}, 0)
+
+			err := connection.SelectWithArgs(&testSlice, "SELECT schemaname, tablename FROM two_columns ORDER BY schemaname LIMIT 2", arg1, arg2)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(testSlice)).To(Equal(2))


### PR DESCRIPTION
Passing query argument is supported in lib/pq like this

q:= `SELECT a from t WHERE b = $1`
db.Query(q, arg1)

Add query argument support for Get and Select.
Only one varadic parameter is allowed for function, the whichConn
parameters is hardcoded to 0.