### PR TITLE
Vendor tools such as ginkgo and goimports

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -31,6 +31,13 @@
   packages = [
     ".",
     "config",
+    "ginkgo",
+    "ginkgo/convert",
+    "ginkgo/interrupthandler",
+    "ginkgo/nodot",
+    "ginkgo/testrunner",
+    "ginkgo/testsuite",
+    "ginkgo/watch",
     "internal/codelocation",
     "internal/containernode",
     "internal/failer",
@@ -117,6 +124,17 @@
   revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
 
 [[projects]]
+  branch = "master"
+  name = "golang.org/x/tools"
+  packages = [
+    "cmd/goimports",
+    "go/ast/astutil",
+    "imports",
+    "internal/fastwalk"
+  ]
+  revision = "c1def519f03ddf76f16b3e444ee1095d73afa01b"
+
+[[projects]]
   name = "gopkg.in/DATA-DOG/go-sqlmock.v1"
   packages = ["."]
   revision = "d76b18b42f285b792bf985118980ce9eacea9d10"
@@ -131,6 +149,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9b48cdf280444383e8c5c9936d12ad65a8970fda7d9d77ac974c91c167d27307"
+  inputs-digest = "3dd0d489ed7b183d66f0597b6a87426d268d22ee6cd4f5b345134fc64b5541ea"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,7 @@
 #   go-tests = true
 #   unused-packages = true
 
+required = ["golang.org/x/tools/cmd/goimports", "github.com/onsi/ginkgo/ginkgo"]
 
 [[constraint]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,12 @@ GOFLAGS :=
 .PHONY : coverage
 
 dependencies :
-		go get golang.org/x/tools/cmd/goimports
-		go get github.com/golang/lint/golint
-		go get github.com/onsi/ginkgo/ginkgo
 		go get github.com/alecthomas/gometalinter
 		gometalinter --install
 		go get github.com/golang/dep/cmd/dep
 		dep ensure
+		@cd vendor/golang.org/x/tools/cmd/goimports; go install .
+		@cd vendor/github.com/onsi/ginkgo/ginkgo; go install .
 
 format :
 		goimports -w .


### PR DESCRIPTION
This will help us to have reproducible  builds as upstream linters and test frameworks change. Also, remove the "go get" for golint since it is vendored with
gometalinter.

Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>