### PR TITLE
Add iohelper package for file reading and writing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint :
 		gometalinter --config=gometalinter.config -s vendor ./...
 
 unit :
-		ginkgo -r -randomizeSuites -randomizeAllSpecs dbconn structmatcher gplog cluster 2>&1
+		ginkgo -r -randomizeSuites -randomizeAllSpecs cluster dbconn gplog iohelper structmatcher 2>&1
 
 test : lint unit
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -239,7 +239,7 @@ func (cluster *Cluster) GetHostForContent(contentID int) string {
  * Helper functions
  */
 
-func GetSegmentConfiguration(connection *dbconn.DBConn) []SegConfig {
+func GetSegmentConfiguration(connection *dbconn.DBConn) ([]SegConfig, error) {
 	query := ""
 	if connection.Version.Before("6") {
 		query = `
@@ -265,8 +265,16 @@ ORDER BY content;`
 
 	results := make([]SegConfig, 0)
 	err := connection.Select(&results, query)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func MustGetSegmentConfiguration(connection *dbconn.DBConn) []SegConfig {
+	segConfigs, err := GetSegmentConfiguration(connection)
 	gplog.FatalOnError(err)
-	return results
+	return segConfigs
 }
 
 func ConstructSSHCommand(host string, cmd string) []string {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -77,7 +77,8 @@ var _ = Describe("cluster/cluster tests", func() {
 		It("returns a configuration for a single-host, single-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...)
 			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
-			results := cluster.GetSegmentConfiguration(connection)
+			results, err := cluster.GetSegmentConfiguration(connection)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(1))
 			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
 			Expect(results[0].Hostname).To(Equal("localhost"))
@@ -85,7 +86,8 @@ var _ = Describe("cluster/cluster tests", func() {
 		It("returns a configuration for a single-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...)
 			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
-			results := cluster.GetSegmentConfiguration(connection)
+			results, err := cluster.GetSegmentConfiguration(connection)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(2))
 			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
 			Expect(results[0].Hostname).To(Equal("localhost"))
@@ -95,7 +97,8 @@ var _ = Describe("cluster/cluster tests", func() {
 		It("returns a configuration for a multi-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...).AddRow(remoteSegOne...)
 			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
-			results := cluster.GetSegmentConfiguration(connection)
+			results, err := cluster.GetSegmentConfiguration(connection)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(3))
 			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
 			Expect(results[0].Hostname).To(Equal("localhost"))

--- a/iohelper/iohelper.go
+++ b/iohelper/iohelper.go
@@ -1,0 +1,112 @@
+package iohelper
+
+/*
+ * This file contains generic file/directory manipulation functions that use
+ * the function pointers and types from the operating package, for easier test
+ * mocking around file IO.
+ */
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/pkg/errors"
+)
+
+/*
+ * The following six OpenFileFor... and MustOpenFileFor... functions abstract
+ * the most common cases for wanting to open files: when reading, open a read-
+ * only handle and ignore file permissions as long as it's readable, and when
+ * writing or appending, create the file if it doesn't exist with relatively
+ * standard 644 permissions and then open it.
+ *
+ * If more niche or complex scenarios are involved, the underlying OpenFileRead
+ * and OpenFileWrite functions should be used directly, to grant more fine-
+ * grained control over flags and permissions.
+ */
+
+func OpenFileForReading(filename string) (operating.ReadCloserAt, error) {
+	fileHandle, err := operating.System.OpenFileRead(filename, os.O_RDONLY, 0644)
+	if err != nil {
+		return nil, errors.Errorf("Unable to open file for reading: %s", err)
+	}
+	return fileHandle, nil
+}
+
+func MustOpenFileForReading(filename string) operating.ReadCloserAt {
+	fileHandle, err := OpenFileForReading(filename)
+	gplog.FatalOnError(err)
+	return fileHandle
+}
+
+func OpenFileForWriting(filename string) (io.WriteCloser, error) {
+	flags := os.O_CREATE | os.O_WRONLY
+	fileHandle, err := operating.System.OpenFileWrite(filename, flags, 0644)
+	if err != nil {
+		return nil, errors.Errorf("Unable to create or open file for writing: %s", err)
+	}
+	return fileHandle, nil
+}
+
+func MustOpenFileForWriting(filename string) io.WriteCloser {
+	fileHandle, err := OpenFileForWriting(filename)
+	gplog.FatalOnError(err)
+	return fileHandle
+}
+
+func OpenFileForAppending(filename string) (io.WriteCloser, error) {
+	flags := os.O_APPEND | os.O_CREATE | os.O_WRONLY
+	fileHandle, err := operating.System.OpenFileWrite(filename, flags, 0644)
+	if err != nil {
+		return nil, errors.Errorf("Unable to create or open file for appending: %s", err)
+	}
+	return fileHandle, nil
+}
+
+func MustOpenFileForAppending(filename string) io.WriteCloser {
+	fileHandle, err := OpenFileForAppending(filename)
+	gplog.FatalOnError(err)
+	return fileHandle
+}
+
+func FileExistsAndIsReadable(filename string) bool {
+	_, err := operating.System.Stat(filename)
+	if err == nil {
+		var fileHandle io.ReadCloser
+		fileHandle, err = OpenFileForReading(filename)
+		if fileHandle != nil {
+			fileHandle.Close()
+		}
+		if err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// Read all lines from a file, stripping whitespace and ignoring empty lines
+func ReadLinesFromFile(filename string) ([]string, error) {
+	fileHandle, err := OpenFileForReading(filename)
+	if err != nil {
+		return nil, err
+	}
+	contents := make([]string, 0)
+	scanner := bufio.NewScanner(fileHandle)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			contents = append(contents, line)
+		}
+	}
+	return contents, nil
+}
+
+func MustReadLinesFromFile(filename string) []string {
+	contents, err := ReadLinesFromFile(filename)
+	gplog.FatalOnError(err)
+	return contents
+}

--- a/iohelper/iohelper_test.go
+++ b/iohelper/iohelper_test.go
@@ -1,0 +1,238 @@
+package iohelper_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/greenplum-db/gp-common-go-libs/iohelper"
+	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestIoHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "iohelper tests")
+}
+
+var _ = BeforeSuite(func() {
+	testhelper.SetupTestLogger()
+})
+
+var (
+	errRead   = errors.New("Unable to open file for reading: Permission denied")
+	errWrite  = errors.New("Unable to create or open file for writing: Permission denied")
+	errAppend = errors.New("Unable to create or open file for appending: Permission denied")
+)
+var _ = Describe("operating/io tests", func() {
+	Describe("File reading and writing functions", func() {
+		AfterEach(func() {
+			operating.System.OpenFileRead = operating.System.OpenFileRead
+			operating.System.OpenFileWrite = operating.System.OpenFileWrite
+		})
+		Describe("OpenFileForReading", func() {
+			It("creates or opens the file for reading", func() {
+				operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) { return os.Stdin, nil }
+				fileHandle, err := iohelper.OpenFileForReading("filename")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fileHandle).To(Equal(os.Stdin))
+			})
+			It("returns an error if one is generated", func() {
+				operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) {
+					return nil, errors.New("Permission denied")
+				}
+				_, err := iohelper.OpenFileForReading("filename")
+				Expect(err.Error()).To(Equal(errRead.Error()))
+			})
+		})
+		Describe("MustOpenFileForReading", func() {
+			It("creates or opens the file for reading", func() {
+				operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) { return os.Stdin, nil }
+				fileHandle := iohelper.MustOpenFileForReading("filename")
+				Expect(fileHandle).To(Equal(os.Stdin))
+			})
+			It("panics on error", func() {
+				operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) {
+					return nil, errors.New("Permission denied")
+				}
+				defer testhelper.ShouldPanicWithMessage(errRead.Error())
+				iohelper.MustOpenFileForReading("filename")
+			})
+		})
+		Describe("OpenFileForWriting", func() {
+			It("creates or opens the file for writing", func() {
+				var passedFlags int
+				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+					passedFlags = flag
+					return os.Stdout, nil
+				}
+				fileHandle, err := iohelper.OpenFileForWriting("filename")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fileHandle).To(Equal(os.Stdout))
+				Expect(passedFlags).To(Equal(os.O_CREATE | os.O_WRONLY))
+			})
+			It("returns an error if one is generated", func() {
+				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+					return nil, errors.New("Permission denied")
+				}
+				_, err := iohelper.OpenFileForWriting("filename")
+				Expect(err.Error()).To(Equal(errWrite.Error()))
+			})
+		})
+		Describe("MustOpenFileForWriting", func() {
+			It("creates or opens the file for writing", func() {
+				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) { return os.Stdout, nil }
+				fileHandle := iohelper.MustOpenFileForWriting("filename")
+				Expect(fileHandle).To(Equal(os.Stdout))
+			})
+			It("panics on error", func() {
+				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+					return nil, errors.New("Permission denied")
+				}
+				defer testhelper.ShouldPanicWithMessage(errWrite.Error())
+				iohelper.MustOpenFileForWriting("filename")
+			})
+		})
+		Describe("OpenFileForAppending", func() {
+			It("creates or opens the file for appending", func() {
+				var passedFlags int
+				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+					passedFlags = flag
+					return os.Stdout, nil
+				}
+				fileHandle, err := iohelper.OpenFileForAppending("filename")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fileHandle).To(Equal(os.Stdout))
+				Expect(passedFlags).To(Equal(os.O_APPEND | os.O_CREATE | os.O_WRONLY))
+			})
+			It("returns an error if one is generated", func() {
+				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+					return nil, errors.New("Permission denied")
+				}
+				_, err := iohelper.OpenFileForAppending("filename")
+				Expect(err.Error()).To(Equal(errAppend.Error()))
+			})
+		})
+		Describe("MustOpenFileForAppending", func() {
+			It("creates or opens the file for writing", func() {
+				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) { return os.Stdout, nil }
+				fileHandle := iohelper.MustOpenFileForAppending("filename")
+				Expect(fileHandle).To(Equal(os.Stdout))
+			})
+			It("panics on error", func() {
+				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+					return nil, errors.New("Permission denied")
+				}
+				defer testhelper.ShouldPanicWithMessage(errAppend.Error())
+				iohelper.MustOpenFileForAppending("filename")
+			})
+		})
+	})
+	Describe("FileExistsAndIsReadable", func() {
+		AfterEach(func() {
+			operating.System = operating.InitializeSystemFunctions()
+		})
+		It("returns true if the file both exists and is readable", func() {
+			operating.System.Stat = func(name string) (os.FileInfo, error) {
+				return nil, nil
+			}
+			operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) {
+				return &os.File{}, nil
+			}
+			check := iohelper.FileExistsAndIsReadable("filename")
+			Expect(check).To(BeTrue())
+		})
+		It("returns false if the file does not exist", func() {
+			operating.System.Stat = func(name string) (os.FileInfo, error) {
+				return nil, os.ErrNotExist
+			}
+			check := iohelper.FileExistsAndIsReadable("filename")
+			Expect(check).To(BeFalse())
+		})
+		It("returns false if there is an error accessing the file", func() {
+			operating.System.Stat = func(name string) (os.FileInfo, error) {
+				return nil, os.ErrPermission
+			}
+			check := iohelper.FileExistsAndIsReadable("filename")
+			Expect(check).To(BeFalse())
+		})
+		It("returns false if there is an error opening the file", func() {
+			operating.System.Stat = func(name string) (os.FileInfo, error) {
+				return nil, nil
+			}
+			operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) {
+				return &os.File{}, &os.PathError{}
+			}
+			check := iohelper.FileExistsAndIsReadable("filename")
+			Expect(check).To(BeFalse())
+		})
+	})
+	Describe("Reading file contents", func() {
+		fileContents := `public.foo
+public."bar%baz"`
+		fileContentsWithWhitespace := `  public.foo
+
+public."bar%baz"  `
+		expectedContents := []string{`public.foo`, `public."bar%baz"`}
+
+		AfterEach(func() {
+			operating.System.OpenFileRead = operating.OpenFileRead
+		})
+		Describe("ReadLinesFromFile", func() {
+			It("reads a file containing multiple lines", func() {
+				testhelper.MockFileContents(fileContents)
+				contents, err := iohelper.ReadLinesFromFile("/tmp/table_file")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(contents).To(Equal(expectedContents))
+			})
+			It("removes extraneous whitespace and empty lines", func() {
+				testhelper.MockFileContents(fileContentsWithWhitespace)
+				contents, err := iohelper.ReadLinesFromFile("/tmp/table_file")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(contents).To(Equal(expectedContents))
+			})
+			It("returns an empty array if the file is empty", func() {
+				testhelper.MockFileContents("")
+				contents, err := iohelper.ReadLinesFromFile("/tmp/table_file")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(contents).To(Equal([]string{}))
+			})
+			It("returns an error if there is an error reading the file", func() {
+				operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) {
+					return nil, errors.New("Permission denied")
+				}
+				contents, err := iohelper.ReadLinesFromFile("/tmp/table_file")
+				Expect(err.Error()).To(Equal(errRead.Error()))
+				Expect(contents).To(BeNil())
+			})
+		})
+		Describe("MustReadLinesFromFile", func() {
+			It("reads a file containing multiple lines", func() {
+				testhelper.MockFileContents(fileContents)
+				contents := iohelper.MustReadLinesFromFile("/tmp/table_file")
+				Expect(contents).To(Equal(expectedContents))
+			})
+			It("removes extraneous whitespace and empty lines", func() {
+				testhelper.MockFileContents(fileContentsWithWhitespace)
+				contents := iohelper.MustReadLinesFromFile("/tmp/table_file")
+				Expect(contents).To(Equal(expectedContents))
+			})
+			It("returns an empty array if the file is empty", func() {
+				testhelper.MockFileContents("")
+				contents := iohelper.MustReadLinesFromFile("/tmp/table_file")
+				Expect(contents).To(Equal([]string{}))
+			})
+			It("panics if there is an error reading the file", func() {
+				operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) {
+					return nil, errors.New("Permission denied")
+				}
+				defer testhelper.ShouldPanicWithMessage(errRead.Error())
+				iohelper.MustReadLinesFromFile("/tmp/table_file")
+			})
+		})
+	})
+})

--- a/show_coverage.sh
+++ b/show_coverage.sh
@@ -2,7 +2,8 @@
 
 DIR="github.com/greenplum-db/gp-common-go-libs"
 RESULTS="/tmp/results.out"
-for PACKAGE in "gplog" "structmatcher" "dbconn" "cluster"; do
+echo "mode: set" > /tmp/coverage.out # Need this line at the start of the file for the total coverage at the end
+for PACKAGE in "cluster" "dbconn" "gplog" "iohelper" "structmatcher"; do
   # Generate code coverage statistics for all packages, write the coverage statistics to a file, and print the coverage percentage to the shell
   go test -coverpkg "$DIR/$PACKAGE" "$DIR/$PACKAGE" -coverprofile="/tmp/unit_$PACKAGE.out" | awk '{printf("%s unit test coverage|%s", $2, $5)}' | awk -F"/" '{print $4}' >> $RESULTS
   # Filter out the first "mode: set" line from each coverage file and concatenate them all

--- a/testhelper/functions.go
+++ b/testhelper/functions.go
@@ -2,6 +2,7 @@ package testhelper
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
@@ -81,4 +82,15 @@ func ShouldPanicWithMessage(message string) {
 func AssertQueryRuns(connection *dbconn.DBConn, query string) {
 	_, err := connection.Exec(query)
 	Expect(err).To(BeNil(), "%s", query)
+}
+
+/*
+ * This function call should be followed by a call to InitializeSystemFunctions
+ * in a defer statement or AfterEach block.
+ */
+func MockFileContents(contents string) {
+	r, w, _ := os.Pipe()
+	operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) { return r, nil }
+	w.Write([]byte(contents))
+	w.Close()
 }


### PR DESCRIPTION
This PR adds a new "iohelper" package containing various helper functions that make use of the OpenFileRead and OpenFileWrite functions in the operating package, to simplify common file reading and writing operations.

---

PR notes:

1) I went with `iohelper` as the package name because "io" is a built-in package and we established the "[foo]helper" pattern with `testhelper`.  If anyone has objections/suggestions, I'm all ears.

2) This isn't in the `operating` package (which would keep everything involving OpenFileRead/OpenFileWrite in one place) because that would cause an import loop between `operating` and `gplog`.

3) This PR also includes a small tweak to GetSegmentConfiguration because I noticed it while writing the iohelper tests and it wasn't big enough to deserve its own PR.  The intention is to make GetSegmentConfiguration usable with gpupgrade so that it can pull in more common-libs stuff.

4) The contents of this package are largely drawn from `utils/io.go` in gpbackup.  Once this goes in, I'll be following it up shortly with a gpbackup PR to remove the extracted code from io.go and use iohelper.go instead.