### PR TITLE
Add errcheck linter

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -136,7 +136,7 @@ func (dbconn *DBConn) Close() {
 	if dbconn.ConnPool != nil {
 		for _, conn := range dbconn.ConnPool {
 			if conn != nil {
-				conn.Close()
+				_ = conn.Close()
 			}
 		}
 		dbconn.ConnPool = nil

--- a/gometalinter.config
+++ b/gometalinter.config
@@ -1,6 +1,6 @@
 {
   "DisableAll": true,
-  "Enable": ["golint", "vet", "varcheck", "unparam"],
+  "Enable": ["golint", "vet", "varcheck", "unparam", "errcheck"],
   "Exclude": [
     "should have comment",
     "comment on exported",

--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -186,9 +186,9 @@ func Info(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
 	message := GetLogPrefix("INFO") + fmt.Sprintf(s, v...)
-	logger.logFile.Output(1, message)
+	_ = logger.logFile.Output(1, message)
 	if logger.verbosity >= LOGINFO {
-		logger.logStdout.Output(1, message)
+		_ = logger.logStdout.Output(1, message)
 	}
 }
 
@@ -196,17 +196,17 @@ func Warn(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
 	message := GetLogPrefix("WARNING") + fmt.Sprintf(s, v...)
-	logger.logFile.Output(1, message)
-	logger.logStdout.Output(1, message)
+	_ = logger.logFile.Output(1, message)
+	_ = logger.logStdout.Output(1, message)
 }
 
 func Verbose(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
 	message := GetLogPrefix("DEBUG") + fmt.Sprintf(s, v...)
-	logger.logFile.Output(1, message)
+	_ = logger.logFile.Output(1, message)
 	if logger.verbosity >= LOGVERBOSE {
-		logger.logStdout.Output(1, message)
+		_ = logger.logStdout.Output(1, message)
 	}
 }
 
@@ -214,9 +214,9 @@ func Debug(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
 	message := GetLogPrefix("DEBUG") + fmt.Sprintf(s, v...)
-	logger.logFile.Output(1, message)
+	_ = logger.logFile.Output(1, message)
 	if logger.verbosity >= LOGDEBUG {
-		logger.logStdout.Output(1, message)
+		_ = logger.logStdout.Output(1, message)
 	}
 }
 
@@ -225,8 +225,8 @@ func Error(s string, v ...interface{}) {
 	defer logMutex.Unlock()
 	message := GetLogPrefix("ERROR") + fmt.Sprintf(s, v...)
 	errorCode = 1
-	logger.logFile.Output(1, message)
-	logger.logStderr.Output(1, message)
+	_ = logger.logFile.Output(1, message)
+	_ = logger.logStderr.Output(1, message)
 }
 
 func Fatal(err error, s string, v ...interface{}) {
@@ -243,7 +243,7 @@ func Fatal(err error, s string, v ...interface{}) {
 		}
 	}
 	message += strings.TrimSpace(fmt.Sprintf(s, v...))
-	logger.logFile.Output(1, message+stackTraceStr)
+	_ = logger.logFile.Output(1, message+stackTraceStr)
 	if logger.verbosity >= LOGVERBOSE {
 		abort(message + stackTraceStr)
 	} else {

--- a/iohelper/iohelper.go
+++ b/iohelper/iohelper.go
@@ -78,7 +78,7 @@ func FileExistsAndIsReadable(filename string) bool {
 		var fileHandle io.ReadCloser
 		fileHandle, err = OpenFileForReading(filename)
 		if fileHandle != nil {
-			fileHandle.Close()
+			_ = fileHandle.Close()
 		}
 		if err == nil {
 			return true

--- a/testhelper/functions.go
+++ b/testhelper/functions.go
@@ -91,6 +91,6 @@ func AssertQueryRuns(connection *dbconn.DBConn, query string) {
 func MockFileContents(contents string) {
 	r, w, _ := os.Pipe()
 	operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) { return r, nil }
-	w.Write([]byte(contents))
-	w.Close()
+	_, _ = w.Write([]byte(contents))
+	_ = w.Close()
 }


### PR DESCRIPTION
This linter ensures that we check the error on functions that return an
error. This will help prevent bugs where we assume that a function such
as Chmod or Open is successful, but forget to check that no error is
returned.

In cases where we do intentionally want to ignore the error, we will now
need to assign it to an empty identifier, such as _ = os.Chmod().

In the this repo, I did not find any additional error checks that we were missing (If we can't write an error or log to stdout, there's not anything we can do beside panic()). However, I think the benefit of catching instances where we forget to check a legitimate error outweigh the additional syntax. Opinions?

Authored-by: Chris Hajas <chajas@pivotal.io>