### PR TITLE
add activerecord from kanas repo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,10 +2,25 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "github.com/apcera/gssapi"
+  packages = ["."]
+  revision = "5fb4217df13b8e6878046fe1e5c10e560e1b86dc"
+
+[[projects]]
   name = "github.com/blang/semver"
   packages = ["."]
   revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
   version = "v3.5.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/greenplum-db/gp-golang-libpq"
+  packages = [
+    ".",
+    "oid"
+  ]
+  revision = "fdb3a7bbb5e884323bbc7d88d17360621624aeb2"
 
 [[projects]]
   branch = "master"
@@ -149,6 +164,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0898a326dc9933990618d3a5497e725420c9131a9d718d4927f24f6f02cc3939"
+  inputs-digest = "63a3708db895869e70d6001f3576216d15d443354c841ce8acd971e1f058f74a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ lint :
 		gometalinter --config=gometalinter.config -s vendor ./...
 
 unit :
-		ginkgo -r -randomizeSuites -randomizeAllSpecs cluster dbconn gplog iohelper structmatcher 2>&1
+		ginkgo -r -randomizeSuites -randomizeAllSpecs cluster dbconn gplog iohelper structmatcher activerecord 2>&1
 
 test : lint unit
 

--- a/activerecord/activerecord.go
+++ b/activerecord/activerecord.go
@@ -1,0 +1,555 @@
+package activerecord
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	pq "github.com/greenplum-db/gp-golang-libpq"
+)
+
+// ActiveRecord represents a database connection and a sql string.
+type ActiveRecord struct {
+	DB     *sql.DB
+	Tokens []string
+	Args   []interface{}
+}
+
+const comma = ","
+const holder = "?"
+
+// NewActiveRecord is the factory method to create an empty ActiveRecord
+func NewActiveRecord() MockableActiveRecord {
+	return &ActiveRecord{}
+}
+
+// NewActiveRecordWithDB return a ActiveRecord with given sql.DB connection
+func NewActiveRecordWithDB(db *sql.DB) MockableActiveRecord {
+	return &ActiveRecord{DB: db}
+}
+
+// Connect connect to dbtype database by provided url.
+func (ar *ActiveRecord) Connect(dbtype string, url string) (err error) {
+	if ar.DB != nil {
+		ar.Close()
+	}
+
+	if ar.DB, err = sql.Open(dbtype, url); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close close the connection.
+func (ar *ActiveRecord) Close() {
+	if ar.DB != nil {
+		err := ar.DB.Close()
+		if err != nil {
+			log.Println(err)
+		}
+	}
+	ar.DB = nil
+}
+
+// Exec will execute the sql string represented by ActiveRecord.
+func (ar *ActiveRecord) Exec() (sql.Result, error) {
+	return ar.DB.Exec(ar.ExecString(), ar.Args...)
+}
+
+// ExecSQL execute the sql string in argument.
+func (ar *ActiveRecord) ExecSQL(sql string, args ...interface{}) (sql.Result, error) {
+	return ar.DB.Exec(sql, args...)
+}
+
+// GetCount get the row count of the result of ActiveRecord sql.
+func (ar *ActiveRecord) GetCount(args ...interface{}) (count int, err error) {
+	ar.Args = append(ar.Args, args)
+	if err = ar.DB.QueryRow(ar.ExecString(), ar.Args...).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// GetRows return the full execution result of ActiveRecord sql, all of the values are in interface{} type.
+func (ar *ActiveRecord) GetRows() (result []map[string]interface{}, err error) {
+	rows, err := ar.DB.Query(ar.ExecString(), ar.Args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := rows.Close()
+		if err != nil {
+			log.Println(err)
+		}
+	}()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	dest := make([]interface{}, len(columns))
+	fields := make([]interface{}, len(columns))
+	for i := range fields {
+		dest[i] = &fields[i]
+	}
+
+	for rows.Next() {
+		if err := rows.Scan(dest...); err != nil {
+			return nil, err
+		}
+
+		r := make(map[string]interface{})
+		for i, v := range fields {
+			if str, ok := v.(string); ok {
+				r[columns[i]] = str
+			} else {
+				switch v.(type) {
+				case time.Time:
+					t := v.(time.Time)
+					r[columns[i]] = t.String()[:19]
+				case []uint8:
+					r[columns[i]] = string(v.([]uint8))
+				default:
+					r[columns[i]] = v
+				}
+			}
+		}
+
+		result = append(result, r)
+	}
+
+	if err := rows.Err(); err != nil {
+		if err == driver.ErrBadConn {
+			return result, nil
+		}
+		return nil, err
+
+	}
+	return result, nil
+}
+
+// GetRowsI get rows as map[string]interface{}
+func (ar *ActiveRecord) GetRowsI(query string, args ...interface{}) (result []map[string]interface{}, err error) {
+
+	rows, err := ar.DB.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := rows.Close()
+		if err != nil {
+			log.Println(err)
+		}
+	}()
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	dest := make([]interface{}, len(columns))
+	fields := make([]interface{}, len(columns))
+	for i := range fields {
+		dest[i] = &fields[i]
+	}
+
+	for rows.Next() {
+		if err := rows.Scan(dest...); err != nil {
+			return nil, err
+		}
+
+		r := make(map[string]interface{})
+		for i, value := range fields {
+			switch v := value.(type) {
+			case sql.NullBool:
+				if v.Valid {
+					r[columns[i]] = v.Bool
+				} else {
+					r[columns[i]] = nil
+				}
+			case sql.NullFloat64:
+				if v.Valid {
+					r[columns[i]] = v.Float64
+				} else {
+					r[columns[i]] = nil
+				}
+			case sql.NullInt64:
+				if v.Valid {
+					r[columns[i]] = v.Int64
+				} else {
+					r[columns[i]] = nil
+				}
+			case sql.NullString:
+				if v.Valid {
+					r[columns[i]] = v.String
+				} else {
+					r[columns[i]] = nil
+				}
+			case pq.NullTime:
+				if v.Valid {
+					r[columns[i]] = v.Time
+				} else {
+					r[columns[i]] = nil
+				}
+			case sql.RawBytes:
+				r[columns[i]] = string(v)
+			case nil:
+				r[columns[i]] = nil
+			case []uint8:
+				r[columns[i]] = string(v)
+			case time.Time:
+				r[columns[i]] = v
+			case int64:
+				r[columns[i]] = v
+			default:
+				r[columns[i]] = v
+			}
+		}
+
+		result = append(result, r)
+	}
+
+	if err := rows.Err(); err != nil {
+		if err == driver.ErrBadConn {
+			return result, nil
+		}
+		return nil, err
+	}
+	return result, nil
+}
+
+// GetRow return the first row of execution result of ActiveRecord sql, all of the values are in interface{} type.
+func (ar *ActiveRecord) GetRow() (map[string]interface{}, error) {
+	rows, err := ar.GetRows()
+	if err != nil || len(rows) == 0 {
+		return nil, err
+	}
+
+	return rows[0], nil
+}
+
+// Select add "select" and the given fields
+func (ar *ActiveRecord) Select(fields ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "SELECT", strings.Join(fields, comma))
+	return ar
+}
+
+// SelectDistinct add "SELECT DISTINCT" and the given fields
+func (ar *ActiveRecord) SelectDistinct(fields ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "SELECT DISTINCT", strings.Join(fields, comma))
+	return ar
+}
+
+// From add "FROM" and the given tables as token
+func (ar *ActiveRecord) From(tables ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "FROM", strings.Join(tables, comma))
+	return ar
+}
+
+// Join add "JOIN" and the given table name
+func (ar *ActiveRecord) Join(table string) MockableActiveRecord {
+	if len(table) > 0 {
+		ar.Tokens = append(ar.Tokens, "JOIN", table)
+	}
+	return ar
+}
+
+// InnerJoin add "INNER JOIN" and the table name
+func (ar *ActiveRecord) InnerJoin(table string) MockableActiveRecord {
+	if len(table) > 0 {
+		ar.Tokens = append(ar.Tokens, "INNER JOIN", table)
+	}
+	return ar
+}
+
+// LeftJoin add "LEFT JOIN" and the table name
+func (ar *ActiveRecord) LeftJoin(table string) MockableActiveRecord {
+	if len(table) > 0 {
+		ar.Tokens = append(ar.Tokens, "LEFT JOIN", table)
+	}
+	return ar
+}
+
+// RightJoin add "RIGHT JOIN" and the table name
+func (ar *ActiveRecord) RightJoin(table string) MockableActiveRecord {
+	if len(table) > 0 {
+		ar.Tokens = append(ar.Tokens, "RIGHT JOIN", table)
+	}
+	return ar
+}
+
+// LeftOuterJoin add "LEFT OUTER JOIN" and the table name
+func (ar *ActiveRecord) LeftOuterJoin(table string) MockableActiveRecord {
+	if len(table) > 0 {
+		ar.Tokens = append(ar.Tokens, "LEFT OUTER JOIN", table)
+	}
+	return ar
+}
+
+// RightOuterJoin add "RIGHT OUTER JOIN" and the table name
+func (ar *ActiveRecord) RightOuterJoin(table string) MockableActiveRecord {
+	if len(table) > 0 {
+		ar.Tokens = append(ar.Tokens, "RIGHT OUTER JOIN", table)
+	}
+	return ar
+}
+
+func (ar *ActiveRecord) appendArgs(args ...interface{}) {
+	ar.Args = append(ar.Args, args...)
+}
+
+// On add "ON" and the condition string into tokens, and args into Args
+func (ar *ActiveRecord) On(cond string, args ...interface{}) MockableActiveRecord {
+	if len(cond) > 0 {
+		ar.Tokens = append(ar.Tokens, "ON", cond)
+		ar.appendArgs(args...)
+	}
+	return ar
+}
+
+// Where add "WHERE" and the condition to tokens, and args into Args
+func (ar *ActiveRecord) Where(cond string, args ...interface{}) MockableActiveRecord {
+	if len(cond) > 0 {
+		ar.Tokens = append(ar.Tokens, "WHERE", cond)
+		ar.appendArgs(args...)
+	}
+	return ar
+}
+
+// And add "AND" and condition into token, and args to Args
+func (ar *ActiveRecord) And(cond string, args ...interface{}) MockableActiveRecord {
+	if len(cond) > 0 {
+		ar.Tokens = append(ar.Tokens, "AND", cond)
+		ar.appendArgs(args...)
+	}
+	return ar
+}
+
+// WhereAnd add conditions into token and args into Args
+func (ar *ActiveRecord) WhereAnd(conds []string, args ...interface{}) MockableActiveRecord {
+	firstNotEmptyFound := false
+	ar.appendArgs(args...)
+	for _, cond := range conds {
+		if len(cond) > 0 {
+			if !firstNotEmptyFound {
+				ar.Tokens = append(ar.Tokens, "WHERE", cond)
+				firstNotEmptyFound = true
+				continue
+			} else {
+				ar.Tokens = append(ar.Tokens, "AND", cond)
+			}
+		}
+	}
+	return ar
+}
+
+// Or add "OR" and condition into tokens, and args into Args
+func (ar *ActiveRecord) Or(cond string, args ...interface{}) MockableActiveRecord {
+	if len(cond) > 0 {
+		ar.Tokens = append(ar.Tokens, "OR", cond)
+		ar.appendArgs(args...)
+	}
+	return ar
+}
+
+// In add "IN" and values into token and args into Args
+func (ar *ActiveRecord) In(vals []string, args ...interface{}) MockableActiveRecord {
+	cond := strings.Join(vals, comma)
+	ar.Tokens = append(ar.Tokens, "IN", "(", cond, ")")
+	ar.appendArgs(args...)
+	return ar
+}
+
+// InAddQuotes is the same as In but the values are quoted with ''
+func (ar *ActiveRecord) InAddQuotes(vals []string, args ...interface{}) MockableActiveRecord {
+	qvals := []string{}
+	for _, val := range vals {
+		qvals = append(qvals, fmt.Sprintf("'%s'", val))
+	}
+	ar.AddArgs(args)
+	return ar.In(qvals)
+}
+
+// OrderBy add "ORDER BY" and the fields joined with comma
+func (ar *ActiveRecord) OrderBy(fields ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "ORDER BY", strings.Join(fields, comma))
+	return ar
+}
+
+// Asc add "ASC" in token, should be used with OrderBy
+func (ar *ActiveRecord) Asc() MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "ASC")
+	return ar
+}
+
+// Desc add "DESC" in token, should be used with OrderBy
+func (ar *ActiveRecord) Desc() MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "DESC")
+	return ar
+}
+
+// Limit add "LIMIT" and the number in tokens
+func (ar *ActiveRecord) Limit(limit int) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "LIMIT", strconv.Itoa(limit))
+	return ar
+}
+
+// Offset add "OFFSET" and the number in tokens
+func (ar *ActiveRecord) Offset(offset int) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "OFFSET", strconv.Itoa(offset))
+	return ar
+}
+
+// GroupBy add "GROUP BY" and the fileds into tokens
+func (ar *ActiveRecord) GroupBy(fields ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "GROUP BY", strings.Join(fields, comma))
+	return ar
+}
+
+// Having add the token "HAVING" and the conditions into tokens, args into Args
+func (ar *ActiveRecord) Having(cond string, args ...interface{}) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "HAVING", cond)
+	ar.appendArgs(args...)
+	return ar
+}
+
+// Update add the token "UPDATE" and the tables name into tokens
+func (ar *ActiveRecord) Update(tables ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "UPDATE", strings.Join(tables, comma))
+	return ar
+}
+
+// Set add the token "SET" and the key values
+func (ar *ActiveRecord) Set(kv ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "SET", strings.Join(kv, comma))
+	return ar
+}
+
+// Show add "SHOW" and key value sting
+func (ar *ActiveRecord) Show(kv string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "Show", kv)
+	return ar
+}
+
+// Delete add "DELETE" and the tables into tokens
+func (ar *ActiveRecord) Delete(tables ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "DELETE")
+	if len(tables) != 0 {
+		ar.Tokens = append(ar.Tokens, strings.Join(tables, comma))
+	}
+	return ar
+}
+
+// InsertInto add "INSERT INTO" and the table into tokens
+func (ar *ActiveRecord) InsertInto(table string, fields ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, "INSERT INTO", table)
+	if len(fields) != 0 {
+		fieldsStr := strings.Join(fields, comma)
+		ar.Tokens = append(ar.Tokens, "(", fieldsStr, ")")
+	}
+	return ar
+}
+
+// Values add "VALUES" and the options values into token
+func (ar *ActiveRecord) Values(vals []string, args ...interface{}) MockableActiveRecord {
+	valsStr := strings.Join(vals, comma)
+	ar.Tokens = append(ar.Tokens, "VALUES", "(", valsStr, ")")
+	ar.appendArgs(args...)
+	return ar
+}
+
+// AddSQL add the given sql into token
+func (ar *ActiveRecord) AddSQL(sql string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, sql)
+	return ar
+}
+
+// Subquery combine a sub query and its alias into (sql) as alias format
+func (ar *ActiveRecord) Subquery(sub string, alias string) string {
+	return fmt.Sprintf("(%s) AS %s", sub, alias)
+}
+
+// SubAR add add another ar as sub ar
+func (ar *ActiveRecord) SubAR(sub MockableActiveRecord, alias string) string {
+	ar.Args = append(ar.Args, sub.GetArgs()...)
+	return fmt.Sprintf("(%s) AS %s", sub.String(), alias)
+}
+
+// ExecString return the sql string represented by Tokens.
+func (ar *ActiveRecord) ExecString() string {
+	str := strings.Join(ar.Tokens, " ")
+	if len(ar.Args) > 0 {
+		for i := range ar.Args {
+			str = strings.Replace(str, holder, fmt.Sprintf("$%d", i+1), 1)
+		}
+	}
+	return str
+}
+
+// String print all the tokens
+func (ar *ActiveRecord) String() string {
+	return strings.Join(ar.Tokens, " ")
+}
+
+// ArgsString print all the arguments
+func (ar *ActiveRecord) ArgsString() string {
+	str := fmt.Sprintf("total length %d\n", len(ar.Args))
+	for i, arg := range ar.Args {
+		str = str + fmt.Sprintf("$%d:%v ", i, arg)
+	}
+	return str
+}
+
+// PrintableString print the sql and arguments
+func (ar *ActiveRecord) PrintableString() string {
+	stoken := strings.Join(ar.Tokens, " ")
+	return fmt.Sprintf("%s\n[%v]\n", stoken, ar.Args)
+}
+
+// CleanTokens clean all tokens
+func (ar *ActiveRecord) CleanTokens() MockableActiveRecord {
+	ar.Tokens = ar.Tokens[:0]
+	ar.Args = ar.Args[:0]
+	return ar
+}
+
+// AddToken append token after the existing Tokens.
+func (ar *ActiveRecord) AddToken(token ...string) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, token...)
+	return ar
+}
+
+// AddArgs append args to ar.Args
+func (ar *ActiveRecord) AddArgs(args ...interface{}) MockableActiveRecord {
+	ar.Args = append(ar.Args, args...)
+	return ar
+}
+
+// AddParenthesis (all the tokens)
+func (ar *ActiveRecord) AddParenthesis() MockableActiveRecord {
+	ar.Tokens = append([]string{"("}, ar.Tokens...)
+	ar.Tokens = append(ar.Tokens, ")")
+	return ar
+}
+
+// Append append another ActiveRecord's Token after the existing Tokens.
+func (ar *ActiveRecord) Append(other MockableActiveRecord) MockableActiveRecord {
+	ar.Tokens = append(ar.Tokens, other.GetTokens()...)
+	ar.Args = append(ar.Args, other.GetArgs()...)
+	return ar
+}
+
+// GetTokens return all ar's Tokens
+func (ar *ActiveRecord) GetTokens() []string {
+	return ar.Tokens
+}
+
+// GetArgs return all ar's args
+func (ar *ActiveRecord) GetArgs() []interface{} {
+	return ar.Args
+}

--- a/activerecord/activerecord_test.go
+++ b/activerecord/activerecord_test.go
@@ -1,0 +1,90 @@
+package activerecord_test
+
+import (
+	. "github.com/greenplum-db/gp-common-go-libs/activerecord"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var db *FakeActiveRecord
+
+var _ = BeforeSuite(func() {
+	db = NewFakeActiveRecord()
+})
+var _ = AfterSuite(func() {
+	db.Close()
+})
+
+var _ = Describe("ActiveRecord", func() {
+	var err error
+
+	Context("test where", func() {
+		BeforeEach(func() {
+			db.CleanTokens()
+			db.Select("ctime").From("database_now").Where("queries_total=?", 3)
+		})
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred(), db.ExecString())
+		})
+		It("sql is correct", func() {
+			Expect(db.String()).To(Equal("SELECT ctime FROM database_now WHERE queries_total=?"))
+		})
+		It("args is correct", func() {
+			Expect(len(db.Args)).To(Equal(1))
+			Expect(db.Args[0]).To(Equal(3))
+		})
+
+	})
+
+	Context("test selectdistinct", func() {
+		BeforeEach(func() {
+			db.CleanTokens()
+			db.SelectDistinct("ctime").From("database_now").Where("queries_total=?", 3)
+		})
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred(), db.ExecString())
+		})
+		It("sql should be right", func() {
+			Expect(db.String()).To(Equal("SELECT DISTINCT ctime FROM database_now WHERE queries_total=?"))
+		})
+		It("args is correct", func() {
+			Expect(len(db.Args)).To(Equal(1))
+			Expect(db.Args[0]).To(Equal(3))
+		})
+
+	})
+
+	Context("test whereand", func() {
+		BeforeEach(func() {
+			db.CleanTokens()
+			db.Select("ctime").From("database_history").WhereAnd([]string{"queries_total=?", "ctime<?"}, 1, "2015-10-28 18:48:00")
+		})
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred(), db.ExecString())
+		})
+		It("sql should be right", func() {
+			Expect(db.String()).To(Equal("SELECT ctime FROM database_history WHERE queries_total=? AND ctime<?"))
+		})
+		It("args is correct", func() {
+			Expect(len(db.Args)).To(Equal(2))
+			Expect(db.Args[0]).To(Equal(1))
+		})
+
+	})
+	Context("test where & and", func() {
+		BeforeEach(func() {
+			db.CleanTokens()
+			filter := new(ActiveRecord)
+			filter.Where("ctime<?", "2015-05-12 21:44:00").And("ctime>=?", "2015-05-12 20:00:00")
+
+			db.Select("ctime").From("database_history").Append(filter)
+		})
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred(), db.ExecString())
+		})
+		It("should have 2 args", func() {
+			Expect(len(db.Args)).To(Equal(2))
+		})
+	})
+
+})

--- a/activerecord/database_suite_test.go
+++ b/activerecord/database_suite_test.go
@@ -1,0 +1,13 @@
+package activerecord_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestActiveRecord(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Active Record Suite")
+}

--- a/activerecord/fake_activerecord.go
+++ b/activerecord/fake_activerecord.go
@@ -1,0 +1,46 @@
+package activerecord
+
+import "database/sql"
+
+// FakeActiveRecord is only for test. You can change MockGetRows to return your own data
+type FakeActiveRecord struct {
+	*ActiveRecord
+	MockGetRows func() ([]map[string]interface{}, error)
+	MockGetRow  func(tokens []string) (map[string]interface{}, error)
+	MockExecSQL func(sql string, args ...interface{}) (sql.Result, error)
+}
+
+// NewFakeActiveRecord return a *FakeActiveRecord
+func NewFakeActiveRecord() *FakeActiveRecord {
+	return &FakeActiveRecord{&ActiveRecord{}, func() ([]map[string]interface{}, error) {
+		return nil, nil
+	}, func(tokens []string) (map[string]interface{}, error) {
+		return nil, nil
+	}, func(sql string, args ...interface{}) (sql.Result, error) {
+		return nil, nil
+	}}
+}
+
+// GetRows will call MockGetRows in MockActiveRecord if it is set
+func (m *FakeActiveRecord) GetRows() ([]map[string]interface{}, error) {
+	if m.MockGetRows != nil {
+		return m.MockGetRows()
+	}
+	return nil, nil
+}
+
+// GetRow will call MockGetRow in MockActiveRecord if it is set
+func (m *FakeActiveRecord) GetRow() (map[string]interface{}, error) {
+	if m.MockGetRow != nil {
+		return m.MockGetRow(m.Tokens)
+	}
+	return nil, nil
+}
+
+// ExecSQL will call MockExecSQL if it is set
+func (m *FakeActiveRecord) ExecSQL(sql string, args ...interface{}) (sql.Result, error) {
+	if m.MockExecSQL != nil {
+		return m.MockExecSQL(sql, args)
+	}
+	return nil, nil
+}

--- a/activerecord/mockable_ar.go
+++ b/activerecord/mockable_ar.go
@@ -1,0 +1,58 @@
+package activerecord
+
+import "database/sql"
+
+// MockableActiveRecord is a mock AR for test usage
+type MockableActiveRecord interface {
+	GetRows() ([]map[string]interface{}, error)
+	GetRow() (map[string]interface{}, error)
+	GetRowsI(query string, args ...interface{}) (result []map[string]interface{}, err error)
+	Exec() (sql.Result, error)
+	GetCount(args ...interface{}) (count int, err error)
+	Connect(dbtype string, url string) (err error)
+	ExecSQL(sql string, args ...interface{}) (sql.Result, error)
+	Select(fields ...string) MockableActiveRecord
+	SelectDistinct(fields ...string) MockableActiveRecord
+	From(tables ...string) MockableActiveRecord
+	Join(table string) MockableActiveRecord
+	InnerJoin(table string) MockableActiveRecord
+	LeftJoin(table string) MockableActiveRecord
+	RightJoin(table string) MockableActiveRecord
+	LeftOuterJoin(table string) MockableActiveRecord
+	RightOuterJoin(table string) MockableActiveRecord
+	On(cond string, args ...interface{}) MockableActiveRecord
+	Where(cond string, args ...interface{}) MockableActiveRecord
+	And(cond string, args ...interface{}) MockableActiveRecord
+	WhereAnd(conds []string, args ...interface{}) MockableActiveRecord
+	Or(cond string, args ...interface{}) MockableActiveRecord
+	In(vals []string, args ...interface{}) MockableActiveRecord
+	InAddQuotes(vals []string, args ...interface{}) MockableActiveRecord
+	OrderBy(fields ...string) MockableActiveRecord
+	Asc() MockableActiveRecord
+	Desc() MockableActiveRecord
+	Limit(limit int) MockableActiveRecord
+	Offset(offset int) MockableActiveRecord
+	GroupBy(fields ...string) MockableActiveRecord
+	Having(cond string, args ...interface{}) MockableActiveRecord
+	Update(tables ...string) MockableActiveRecord
+	Set(kv ...string) MockableActiveRecord
+	Show(kv string) MockableActiveRecord
+	Delete(tables ...string) MockableActiveRecord
+	InsertInto(table string, fields ...string) MockableActiveRecord
+	Values(vals []string, args ...interface{}) MockableActiveRecord
+	AddSQL(sql string) MockableActiveRecord
+	AddToken(token ...string) MockableActiveRecord
+	AddArgs(args ...interface{}) MockableActiveRecord
+	AddParenthesis() MockableActiveRecord
+	Append(other MockableActiveRecord) MockableActiveRecord
+	CleanTokens() MockableActiveRecord
+	GetTokens() []string
+	GetArgs() []interface{}
+	Close()
+	String() string
+	Subquery(sub string, alias string) string
+	ExecString() string
+	SubAR(sub MockableActiveRecord, alias string) string
+	ArgsString() string
+	PrintableString() string
+}


### PR DESCRIPTION
active record is used by GPCC team. 
1. GPCC use this go lib to connect to gpdb
2. It has mockable interface to make test much easier. 
3. It support kerberos
4. It gives both programming way to write sql like Select("c1").From("table1"), and also a traditional way.

It originally located at the private repo "greenplum-db/kanas", we decided to move it to this public repo in https://www.pivotaltracker.com/story/show/156839319

It need greenplun-db/gp-golang-libpq (a kerberos supported pq) as the connection driver to greenplum. Also, gssapi lib (github.com/apcera/gssapi) is needed too.