### PR TITLE
Add LocalOutput to TestExecutor

### DIFF
--- a/testhelper/structs.go
+++ b/testhelper/structs.go
@@ -36,6 +36,7 @@ func (result TestResult) RowsAffected() (int64, error) {
 }
 
 type TestExecutor struct {
+	LocalOutput     string
 	LocalError      error
 	LocalCommands   []string
 	ClusterOutput   *cluster.RemoteOutput
@@ -48,9 +49,9 @@ func (executor *TestExecutor) ExecuteLocalCommand(commandStr string) (string, er
 	executor.NumExecutions++
 	executor.LocalCommands = append(executor.LocalCommands, commandStr)
 	if executor.ErrorOnExecNum == 0 || executor.NumExecutions == executor.ErrorOnExecNum {
-		return "", executor.LocalError
+		return executor.LocalOutput, executor.LocalError
 	}
-	return "", nil
+	return executor.LocalOutput, nil
 }
 
 func (executor *TestExecutor) ExecuteClusterCommand(scope int, commandMap map[int][]string) *cluster.RemoteOutput {


### PR DESCRIPTION
We need to specify outputs of command run locally. This seems the minimal change to get us working. 

