### PR TITLE
Use pgx postgres driver instead of pq

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
+	_ "github.com/jackc/pgx/stdlib" // Need driver for postgres
 	"github.com/jmoiron/sqlx"
-	_ "github.com/lib/pq" // Need driver for postgres
 	"github.com/pkg/errors"
 )
 
@@ -189,10 +189,10 @@ func (dbconn *DBConn) Connect(numConns int) error {
 	}
 	dbname := EscapeConnectionParam(dbconn.DBName)
 	user := EscapeConnectionParam(dbconn.User)
-	connStr := fmt.Sprintf(`user='%s' dbname='%s' host=%s port=%d sslmode=disable`, user, dbname, dbconn.Host, dbconn.Port)
+	connStr := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable", user, dbconn.Host, dbconn.Port, dbname)
 	dbconn.ConnPool = make([]*sqlx.DB, numConns)
 	for i := 0; i < numConns; i++ {
-		conn, err := dbconn.Driver.Connect("postgres", connStr)
+		conn, err := dbconn.Driver.Connect("pgx", connStr)
 		err = dbconn.handleConnectionError(err)
 		if err != nil {
 			return err


### PR DESCRIPTION
pq had an issue with character encoding for Thai characters, but pgx does
not seem to have the same issue. Performance seems to be the same and
the amount of code we need to change is very minimal.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>