### PR TITLE
Remove build target from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: depend build test
+all: depend test
 
 SHELL := /bin/bash
 .DEFAULT_GOAL := all


### PR DESCRIPTION
There is no build target, so `make` should not attempt to execute that
target.

Fixes https://github.com/greenplum-db/gp-common-go-libs/issues/22

Authored-by: Chris Hajas <chajas@pivotal.io>