### PR TITLE
Improve SelectString and SelectStringSlice

### DIFF
--- a/dbconn/dbconn_test.go
+++ b/dbconn/dbconn_test.go
@@ -365,9 +365,11 @@ var _ = Describe("dbconn/dbconn tests", func() {
 		})
 	})
 	Describe("MustSelectString", func() {
-		header := []string{"string"}
+		header := []string{"foo"}
 		rowOne := []driver.Value{"one"}
 		rowTwo := []driver.Value{"two"}
+		headerExtraCol := []string{"foo", "bar"}
+		rowExtraCol := []driver.Value{"one", "two"}
 
 		It("returns a single string if the query selects a single string", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(rowOne...)
@@ -381,17 +383,25 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			result := dbconn.MustSelectString(connection, "SELECT foo FROM bar")
 			Expect(result).To(Equal(""))
 		})
-		It("panics if the query selects multiple strings", func() {
+		It("panics if the query selects multiple rows", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(rowOne...).AddRow(rowTwo...)
 			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
 			defer testhelper.ShouldPanicWithMessage("Too many rows returned from query: got 2 rows, expected 1 row")
 			dbconn.MustSelectString(connection, "SELECT foo FROM bar")
 		})
+		It("panics if the query selects multiple columns", func() {
+			fakeResult := sqlmock.NewRows(headerExtraCol).AddRow(rowExtraCol...)
+			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
+			defer testhelper.ShouldPanicWithMessage("Too many columns returned from query: got 2 columns, expected 1 column")
+			dbconn.MustSelectString(connection, "SELECT foo FROM bar")
+		})
 	})
 	Describe("MustSelectStringSlice", func() {
-		header := []string{"string"}
+		header := []string{"foo"}
 		rowOne := []driver.Value{"one"}
 		rowTwo := []driver.Value{"two"}
+		headerExtraCol := []string{"foo", "bar"}
+		rowExtraCol := []driver.Value{"one", "two"}
 
 		It("returns a slice containing a single string if the query selects a single string", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(rowOne...)
@@ -406,13 +416,19 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			results := dbconn.MustSelectStringSlice(connection, "SELECT foo FROM bar")
 			Expect(len(results)).To(Equal(0))
 		})
-		It("returns a slice containing multiple strings if the query selects multiple strings", func() {
+		It("returns a slice containing multiple strings if the query selects multiple rows", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(rowOne...).AddRow(rowTwo...)
 			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
 			results := dbconn.MustSelectStringSlice(connection, "SELECT foo FROM bar")
 			Expect(len(results)).To(Equal(2))
 			Expect(results[0]).To(Equal("one"))
 			Expect(results[1]).To(Equal("two"))
+		})
+		It("panics if the query selects multiple columns", func() {
+			fakeResult := sqlmock.NewRows(headerExtraCol).AddRow(rowExtraCol...)
+			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
+			defer testhelper.ShouldPanicWithMessage("Too many columns returned from query: got 2 columns, expected 1 column")
+			dbconn.MustSelectString(connection, "SELECT foo FROM bar")
 		})
 	})
 })


### PR DESCRIPTION
Previously, these two functions used a generic struct with a "String" field to
execute the provided query with sqlx.Select.  This required any queries passed
to them to be of the form "SELECT [field] AS string" so that the results would
match the struct, and any fields that could not be aliased that way (such as
selecting GUCs with "SHOW [name]") could not be selected with these functions.

This commit modifies the functions to execute the query with Queryx instead of
Select, then scans in values from the underlying sql.Rows into sql.NullStrings,
which removes the need to alias fields in queries and allows for selecting GUCs
and NULL values with these functions.

Authored-by: Jamie McAtamney <jmcatamney@pivotal.io>