### PR TITLE
Exclude noisy Cobra traces from stack trace in gplog

### DIFF
--- a/gplog/gplog_test.go
+++ b/gplog/gplog_test.go
@@ -155,6 +155,23 @@ var _ = Describe("logger/log tests", func() {
 				gplog.FatalOnError(errors.New("this is an error"), "this is output")
 			})
 		})
+		Describe("FormatStackTrace", func() {
+			It("Prints the stack trace of an error", func() {
+				cause := errors.New("some error")
+				err := errors.Wrap(cause, "some text")
+				result := gplog.FormatStackTrace(err)
+				Expect(result).To(ContainSubstring("ginkgo_dsl.go"))
+				Expect(result).To(ContainSubstring("gplog_test.go"))
+
+			})
+			It("does not return unnecessary traces in the stack", func() {
+				cause := errors.New("some error")
+				err := errors.Wrap(cause, "some text")
+				result := gplog.FormatStackTrace(err)
+				Expect(result).To(Not(ContainSubstring("runtime.goexit")))
+
+			})
+		})
 		Describe("Verbosity set to Error", func() {
 			BeforeEach(func() {
 				gplog.SetVerbosity(gplog.LOGERROR)


### PR DESCRIPTION
Previously, gplog would print the entire stack trace which may include
unhelpful traces involving the CLI framework or general low level call. This commit provides a means to exclude such statements.

Currently, it will exclude trace lines containing "cobra/command.go", "runtime.main", or "runtime.goexit". I'm not sure if we could possibly see this in a legit stack trace that we wanted or if these would always be pure noise.

Stack trace without filtering:

```
20180801:10:47:54 gpbackup:chajas:chris_mac:001263-[CRITICAL]:-FATAL: database "test1" does not exist
github.com/greenplum-db/gpbackup/vendor/github.com/greenplum-db/gp-common-go-libs/gplog.FatalOnError
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/vendor/github.com/greenplum-db/gp-common-go-libs/gplog/gplog.go:257
github.com/greenplum-db/gpbackup/vendor/github.com/greenplum-db/gp-common-go-libs/dbconn.(*DBConn).MustConnect
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/vendor/github.com/greenplum-db/gp-common-go-libs/dbconn/dbconn.go:185
github.com/greenplum-db/gpbackup/backup.InitializeConnectionPool
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/backup/wrappers.go:39
github.com/greenplum-db/gpbackup/backup.DoSetup
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/backup/backup.go:77
main.main.func1
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/gpbackup.go:22
github.com/greenplum-db/gpbackup/vendor/github.com/spf13/cobra.(*Command).execute
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/vendor/github.com/spf13/cobra/command.go:766
github.com/greenplum-db/gpbackup/vendor/github.com/spf13/cobra.(*Command).ExecuteC
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/vendor/github.com/spf13/cobra/command.go:852
github.com/greenplum-db/gpbackup/vendor/github.com/spf13/cobra.(*Command).Execute
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/vendor/github.com/spf13/cobra/command.go:800
main.main
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/gpbackup.go:27
runtime.main
	/usr/local/Cellar/go/1.10.3/libexec/src/runtime/proc.go:198
runtime.goexit
	/usr/local/Cellar/go/1.10.3/libexec/src/runtime/asm_amd64.s:2361
```

Stack trace with filtering:
```
20180801:10:47:04 gpbackup:chajas:chris_mac:001048-[CRITICAL]:-FATAL: database "test1" does not exist
github.com/greenplum-db/gpbackup/vendor/github.com/greenplum-db/gp-common-go-libs/gplog.FatalOnError
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/vendor/github.com/greenplum-db/gp-common-go-libs/gplog/gplog.go:257
github.com/greenplum-db/gpbackup/vendor/github.com/greenplum-db/gp-common-go-libs/dbconn.(*DBConn).MustConnect
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/vendor/github.com/greenplum-db/gp-common-go-libs/dbconn/dbconn.go:185
github.com/greenplum-db/gpbackup/backup.InitializeConnectionPool
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/backup/wrappers.go:39
github.com/greenplum-db/gpbackup/backup.DoSetup
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/backup/backup.go:77
main.main.func1
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/gpbackup.go:22
main.main
	/Users/chajas/go/src/github.com/greenplum-db/gpbackup/gpbackup.go:27
```

Authored-by: Chris Hajas <chajas@pivotal.io>