### PR TITLE
Remove filtering from stack trace

### DIFF
--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -237,7 +237,7 @@ func Fatal(err error, s string, v ...interface{}) {
 	stackTraceStr := ""
 	if err != nil {
 		message += fmt.Sprintf("%v", err)
-		stackTraceStr = formatStackTrace(errors.WithStack(err))
+		stackTraceStr = fmt.Sprintf("%+v", errors.WithStack(err))
 		if s != "" {
 			message += ": "
 		}
@@ -259,16 +259,6 @@ func FatalOnError(err error, output ...string) {
 			Fatal(err, output[0])
 		}
 	}
-}
-
-type stackTracer interface {
-	StackTrace() errors.StackTrace
-}
-
-func formatStackTrace(err error) string {
-	st := err.(stackTracer).StackTrace()
-	message := fmt.Sprintf("%+v", st[1:len(st)-2])
-	return message
 }
 
 /*


### PR DESCRIPTION
Previously, we filtered out lines of the stack trace that are not
related to the codebase. However, we should not ever have any doubt that
relevant or important information may have been filtered out.

Authored-by: Chris Hajas <chajas@pivotal.io>