### PR TITLE
Improve GPDB version handling in dbconn

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -208,6 +208,11 @@ func (dbconn *DBConn) Connect(numConns int) error {
 	}
 	dbconn.Tx = make([]*sqlx.Tx, numConns)
 	dbconn.NumConns = numConns
+	version, err := InitializeVersion(dbconn)
+	if err != nil {
+		return errors.Wrap(err, "Failed to determine database version")
+	}
+	dbconn.Version = version
 	return nil
 }
 

--- a/dbconn/dbconn_test.go
+++ b/dbconn/dbconn_test.go
@@ -41,6 +41,12 @@ var _ = BeforeEach(func() {
 	connection, mock = testhelper.CreateAndConnectMockDB(1)
 })
 
+var _ = AfterEach(func() {
+	if connection != nil {
+		connection.Close()
+	}
+})
+
 var _ = Describe("dbconn/dbconn tests", func() {
 	BeforeEach(func() {
 		operating.System.Now = func() time.Time { return time.Date(2017, time.January, 1, 1, 1, 1, 1, time.Local) }
@@ -73,17 +79,8 @@ var _ = Describe("dbconn/dbconn tests", func() {
 	Describe("DBConn.MustConnect", func() {
 		var mockdb *sqlx.DB
 		BeforeEach(func() {
-			mockdb, mock = testhelper.CreateMockDB()
-			if connection != nil {
-				connection.Close()
-			}
-			connection = dbconn.NewDBConnFromEnvironment("testdb")
-			connection.Driver = testhelper.TestDriver{DB: mockdb, User: "testrole"}
-		})
-		AfterEach(func() {
-			if connection != nil {
-				connection.Close()
-			}
+			connection, mock = testhelper.CreateMockDBConn()
+			testhelper.ExpectVersionQuery(mock, "5.1.0")
 		})
 		It("makes a single connection successfully if the database exists", func() {
 			connection.MustConnect(1)
@@ -127,11 +124,9 @@ var _ = Describe("dbconn/dbconn tests", func() {
 		})
 	})
 	Describe("DBConn.Close", func() {
-		var mockdb *sqlx.DB
 		BeforeEach(func() {
-			mockdb, mock = testhelper.CreateMockDB()
-			connection = dbconn.NewDBConnFromEnvironment("testdb")
-			connection.Driver = testhelper.TestDriver{DB: mockdb, User: "testrole"}
+			connection, mock = testhelper.CreateMockDBConn()
+			testhelper.ExpectVersionQuery(mock, "5.1.0")
 		})
 		It("successfully closes a dbconn with a single open connection", func() {
 			connection.MustConnect(1)
@@ -337,11 +332,9 @@ var _ = Describe("dbconn/dbconn tests", func() {
 	})
 	Describe("Dbconn.ValidateConnNum", func() {
 		BeforeEach(func() {
-			connection.Close()
+			connection, mock = testhelper.CreateMockDBConn()
+			testhelper.ExpectVersionQuery(mock, "5.1.0")
 			connection.MustConnect(3)
-		})
-		AfterEach(func() {
-			connection.Close()
 		})
 		It("returns the connection number if it is valid", func() {
 			num := connection.ValidateConnNum(1)


### PR DESCRIPTION
Previously, after connecting to GPDB with DBConn.Connect, a separate call to
DBConn.Version.Initialize(DBConn) was required to retrieve and set the version.
The original reasons for requiring a separate step to get the version no longer
apply, and having to make an extra call every time is irritating, so this commit
modifies DBConn.Connect to retrieve and set the version automatically.

It also adds a few new helper functions:

- dbconn.NewDBVersion, for creating sample GPDBVersions in tests.
- testhelper.CreateMockDBConn, for when you want to create a connection but
  don't want to connect yet.
- testhelper.ExpectVersionQuery, for setting a database version for a function
  that will Connect to a mock database with a DBConn.

----------

This PR makes a breaking change by altering `Initialize` and no longer requiring it to be called directly.  I've already made branches with the necessary changes to `gpbackup`, `gpcopy`, and `gpupgrade`, to be PR'ed once this PR goes in.