### PR TITLE
Fix dbconn to properly handle database names with special characters

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -193,9 +193,9 @@ func (dbconn *DBConn) Connect(numConns int) error {
 	if dbconn.ConnPool != nil {
 		return errors.Errorf("The database connection must be closed before reusing the connection")
 	}
-	dbname := EscapeConnectionParam(dbconn.DBName)
-	user := EscapeConnectionParam(dbconn.User)
-	connStr := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable", user, dbconn.Host, dbconn.Port, dbname)
+	// This string takes in the literal user/database names. They do not need to be escaped or quoted.
+	connStr := fmt.Sprintf("postgres://%s@%s:%d/%s?sslmode=disable", dbconn.User, dbconn.Host, dbconn.Port, dbconn.DBName)
+
 	dbconn.ConnPool = make([]*sqlx.DB, numConns)
 	for i := 0; i < numConns; i++ {
 		conn, err := dbconn.Driver.Connect("pgx", connStr)
@@ -314,16 +314,6 @@ func (dbconn *DBConn) ValidateConnNum(whichConn ...int) int {
 		gplog.Fatal(errors.Errorf("Invalid connection number: %d", whichConn[0]), "")
 	}
 	return whichConn[0]
-}
-
-/*
- * Other useful/helper functions involving DBConn
- */
-
-func EscapeConnectionParam(param string) string {
-	param = strings.Replace(param, `\`, `\\`, -1)
-	param = strings.Replace(param, `'`, `\'`, -1)
-	return param
 }
 
 /*


### PR DESCRIPTION
In commit 7b9de4e07bbf939f16877a9e7cc5c32bb5f82c46, we switched from
using libpq to pgx. This involved using a different format of the
connection string that does not require escaping the database or
user.

Additionally, remove the EscapeConnectionParam function since it is
error-prone and unused in the gpdb repos as far as I can tell.

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Kevin Yeap <kyeap@pivotal.io>