### PR TITLE
Log host and port info in dbconn errors

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -221,16 +221,19 @@ func (dbconn *DBConn) handleConnectionError(err error) error {
 	if err != nil {
 		if strings.Contains(err.Error(), "does not exist") {
 			if strings.Contains(err.Error(), "pq: role") {
-				return errors.Errorf(`Role "%s" does not exist, exiting`, dbconn.User)
+				return errors.Errorf(`Role "%s" does not exist on %s:%d, exiting`, dbconn.User, dbconn.Host, dbconn.Port)
 			} else if strings.Contains(err.Error(), "pq: database") {
-				return errors.Errorf(`Database "%s" does not exist, exiting`, dbconn.DBName)
+				return errors.Errorf(`Database "%s" does not exist on %s:%d, exiting`, dbconn.DBName, dbconn.Host, dbconn.Port)
 			}
 		} else if strings.Contains(err.Error(), "connection refused") {
 			return errors.Errorf(`could not connect to server: Connection refused
 	Is the server running on host "%s" and accepting
 	TCP/IP connections on port %d?`, dbconn.Host, dbconn.Port)
+		} else {
+			return errors.Errorf("%v (%s:%d)", err, dbconn.Host, dbconn.Port)
 		}
 	}
+
 	return err
 }
 

--- a/dbconn/dbconn_test.go
+++ b/dbconn/dbconn_test.go
@@ -108,7 +108,7 @@ var _ = Describe("dbconn/dbconn tests", func() {
 		It("fails if the database does not exist", func() {
 			connection.Driver = testhelper.TestDriver{ErrToReturn: fmt.Errorf("pq: database \"testdb\" does not exist"), DB: mockdb, DBName: "testdb", User: "testrole"}
 			Expect(connection.DBName).To(Equal("testdb"))
-			defer testhelper.ShouldPanicWithMessage("Database \"testdb\" does not exist, exiting")
+			defer testhelper.ShouldPanicWithMessage("Database \"testdb\" does not exist on testhost:5432, exiting")
 			connection.MustConnect(1)
 		})
 		It("fails if the role does not exist", func() {
@@ -119,7 +119,8 @@ var _ = Describe("dbconn/dbconn tests", func() {
 			connection = dbconn.NewDBConnFromEnvironment("testdb")
 			connection.Driver = testhelper.TestDriver{ErrToReturn: fmt.Errorf("pq: role \"nonexistent\" does not exist"), DB: mockdb, DBName: "testdb", User: "nonexistent"}
 			Expect(connection.User).To(Equal("nonexistent"))
-			defer testhelper.ShouldPanicWithMessage("Role \"nonexistent\" does not exist, exiting")
+			expectedStr := fmt.Sprintf("Role \"nonexistent\" does not exist on %s:%d, exiting", connection.Host, connection.Port)
+			defer testhelper.ShouldPanicWithMessage(expectedStr)
 			connection.MustConnect(1)
 		})
 	})

--- a/testhelper/functions.go
+++ b/testhelper/functions.go
@@ -60,6 +60,8 @@ func CreateMockDBConn() (*dbconn.DBConn, sqlmock.Sqlmock) {
 	driver := TestDriver{DB: mockdb, DBName: "testdb", User: "testrole"}
 	connection := dbconn.NewDBConnFromEnvironment("testdb")
 	connection.Driver = driver
+	connection.Host = "testhost"
+	connection.Port = 5432
 	return connection, mock
 }
 


### PR DESCRIPTION
It's useful to spot the error when trying to connect multiple clusters
at the same time.