### PR TITLE
Create cluster copy command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 vendor
+
+.idea


### PR DESCRIPTION
The UD team uses the `gp-common-go-libs` in the PXF command-line utility. We recently implemented a feature that required copying files to remote hosts, but we were lacking a "copy" command.

Here is an implementation of a copy command that attempts to reuse as much code as possible from the ssh command. It uses rsync, maybe this can be configurable by the user to use scp.

In the process, I also decided to try to tackle the issue of `contentID` not being meaningful when doing commands/copies involving **hosts**. This required a change of the API.