### PR TITLE
OpenFileForWriting(): add flag to truncate any existing content

### DIFF
--- a/iohelper/iohelper.go
+++ b/iohelper/iohelper.go
@@ -43,7 +43,7 @@ func MustOpenFileForReading(filename string) operating.ReadCloserAt {
 }
 
 func OpenFileForWriting(filename string) (io.WriteCloser, error) {
-	flags := os.O_CREATE | os.O_WRONLY
+	flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 	fileHandle, err := operating.System.OpenFileWrite(filename, flags, 0644)
 	if err != nil {
 		return nil, errors.Errorf("Unable to create or open file for writing: %s", err)

--- a/iohelper/iohelper_test.go
+++ b/iohelper/iohelper_test.go
@@ -63,7 +63,7 @@ var _ = Describe("operating/io tests", func() {
 			})
 		})
 		Describe("OpenFileForWriting", func() {
-			It("creates or opens the file for writing", func() {
+			It("creates or opens the file for writing, and truncates any existing content", func() {
 				var passedFlags int
 				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
 					passedFlags = flag
@@ -72,7 +72,7 @@ var _ = Describe("operating/io tests", func() {
 				fileHandle, err := iohelper.OpenFileForWriting("filename")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(fileHandle).To(Equal(os.Stdout))
-				Expect(passedFlags).To(Equal(os.O_CREATE | os.O_WRONLY))
+				Expect(passedFlags).To(Equal(os.O_CREATE | os.O_WRONLY | os.O_TRUNC))
 			})
 			It("returns an error if one is generated", func() {
 				operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {


### PR DESCRIPTION
* Callers of OpenFileForWriting() expect to overwrite any existing content, so add the os.O_TRUNC flag. Otherwise, if an existing file is opened with existing content, the caller will find that any original content that was *longer* than newly written content will be left behind.
