### PR TITLE
Add two features in gplog

### DIFF
--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -79,6 +79,7 @@ const (
  * - Fatal: Messages indicating that the program cannot proceed, e.g. the database
  *          cannot be reached.  This function will exit the program after printing
  *          the error message.
+ * - FatalWithoutPanic: Same as Fatal, but will not trigger panic. Just exit(1).
  */
 type LogPrefixFunc func(string) string
 type LogFileNameFunc func(string, string) string
@@ -305,7 +306,7 @@ func FatalWithoutPanic(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()
 	message := GetLogPrefix("CRITICAL") + fmt.Sprintf(s, v...)
-	errorCode = 1
+	errorCode = 2
 	_ = logger.logFile.Output(1, message)
 	_ = logger.logStderr.Output(1, message)
 	os.Exit(1)

--- a/gplog/gplog_test.go
+++ b/gplog/gplog_test.go
@@ -499,6 +499,16 @@ var _ = Describe("logger/log tests", func() {
 					gplog.Fatal(errors.New(expectedMessage), "")
 				})
 			})
+			Context("FatalWithoutPanic", func() {
+				It("prints to the log file, then exit(1)", func() {
+					gplog.SetExitFunc(func() {})
+					expectedMessage := "logfile error fatalwithoutpanic"
+					gplog.FatalWithoutPanic(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, fatalExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, fatalExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, fatalExpected+expectedMessage)
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
- A new function FatalWithoutPanic, same as Fatal but will not panic and will exit(1)
- Enable user to customize the log file name

According to issue https://github.com/greenplum-db/gp-common-go-libs/issues/41