### PR TITLE
Refactor command execution framework

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -19,15 +19,28 @@ import (
 
 type Executor interface {
 	ExecuteLocalCommand(commandStr string) (string, error)
-	ExecuteClusterCommand(scope int, commandMap map[int][]string) *RemoteOutput
+	ExecuteClusterCommand(scope int, commandList []ShellCommand) *RemoteOutput
 }
 
 // This type only exists to allow us to mock Execute[...]Command functions for testing
 type GPDBExecutor struct{}
 
+/*
+ * A Cluster object stores information about the cluster in three ways:
+ * - Segments is basically equivalent to gp_segment_configuration, a plain
+ *   list of segment information, and is ordered by content id.
+ * - ByContent is a map of content id to the single corresponding segment.
+ * - ByHost is a map of hostname to all of the segments on that host.
+ * The maps are only stored for efficient lookup; Segments is the "source of
+ * truth" for the cluster.  The maps actually hold pointers to the SegConfigs
+ * in Segments, so modifying Segments will modify the maps as well.
+ */
 type Cluster struct {
 	ContentIDs []int
-	Segments   map[int]SegConfig
+	Hostnames  []string
+	Segments   []SegConfig
+	ByContent  map[int]*SegConfig
+	ByHost     map[string][]*SegConfig
 	Executor
 }
 
@@ -40,8 +53,8 @@ type SegConfig struct {
 }
 
 /*
- * We pass values from this enum into GenerateAndExecuteCommand to define the
- * nature and scope of the command execution.
+ * We pass values from this enum into ShellCommands, RemoteOutputs, and associated
+ * functions to define the nature and scope of the command execution.
  * - ON_SEGMENTS:            Execute on each segment, excluding the master.
  * - ON_SEGMENTS_AND_MASTER: Execute on each segment, including the master.
  * - ON_HOSTS:               Execute on each host, excluding the master host.
@@ -64,13 +77,75 @@ const (
 	ON_MASTER_TO_HOSTS_AND_MASTER
 )
 
+func scopeIsRemote(scope int) bool {
+	return scope == ON_SEGMENTS || scope == ON_SEGMENTS_AND_MASTER || scope == ON_HOSTS || scope == ON_HOSTS_AND_MASTER
+}
+
+func scopeIncludesMaster(scope int) bool {
+	return scope == ON_SEGMENTS_AND_MASTER || scope == ON_MASTER_TO_SEGMENTS_AND_MASTER || scope == ON_HOSTS_AND_MASTER || scope == ON_MASTER_TO_HOSTS_AND_MASTER
+}
+
+func scopeIsHosts(scope int) bool {
+	return scope == ON_HOSTS || scope == ON_HOSTS_AND_MASTER || scope == ON_MASTER_TO_HOSTS || scope == ON_MASTER_TO_HOSTS_AND_MASTER
+}
+
+/*
+ * A ShellCommand stores a command to be executed (in both executable and
+ * display form), as well as the results of the command execution and the
+ * necessary information to determine how the command will be or was executed.
+ *
+ * It is assumed that before a caller references Content or Host for a given
+ * command, they will check Scope to ensure that that field is meaningful for
+ * that command.  GenerateCommandList sets Host to "" for per-segment commands
+ * and Content to -2 for per-host commands, just to be safe.
+ */
+type ShellCommand struct {
+	Scope         int
+	Content       int
+	Host          string
+	Command       *exec.Cmd
+	CommandString string
+	Stdout        string
+	Stderr        string
+	Error         error
+}
+
+func NewShellCommand(scope int, content int, host string, command []string) ShellCommand {
+	return ShellCommand{
+		Scope:         scope,
+		Content:       content,
+		Host:          host,
+		Command:       exec.Command(command[0], command[1:]...),
+		CommandString: strings.Join(command, " "),
+	}
+}
+
+/*
+ * A RemoteOutput is used to make it easier to identify the success or failure
+ * of a cluster command and to display the results to the user.
+ */
 type RemoteOutput struct {
-	Scope     int
-	NumErrors int
-	Stdouts   map[int]string
-	Stderrs   map[int]string
-	Errors    map[int]error
-	CmdStrs   map[int]string
+	Scope          int
+	NumErrors      int
+	Commands       []ShellCommand
+	FailedCommands []*ShellCommand
+}
+
+func NewRemoteOutput(scope int, numErrors int, commands []ShellCommand) *RemoteOutput {
+	failedCommands := make([]*ShellCommand, numErrors)
+	index := 0
+	for i := range commands {
+		if commands[i].Error != nil {
+			failedCommands[index] = &commands[i]
+			index++
+		}
+	}
+	return &RemoteOutput{
+		Scope:          scope,
+		NumErrors:      numErrors,
+		Commands:       commands,
+		FailedCommands: failedCommands,
+	}
 }
 
 /*
@@ -79,78 +154,85 @@ type RemoteOutput struct {
 
 func NewCluster(segConfigs []SegConfig) *Cluster {
 	cluster := Cluster{}
-	cluster.Segments = make(map[int]SegConfig, len(segConfigs))
-	for _, seg := range segConfigs {
-		cluster.ContentIDs = append(cluster.ContentIDs, seg.ContentID)
-		cluster.Segments[seg.ContentID] = seg
+	cluster.Segments = segConfigs
+	cluster.ByContent = make(map[int]*SegConfig, len(segConfigs))
+	cluster.ByHost = make(map[string][]*SegConfig, 0)
+	for i := range cluster.Segments {
+		segment := &cluster.Segments[i]
+		cluster.ContentIDs = append(cluster.ContentIDs, segment.ContentID)
+		cluster.ByContent[segment.ContentID] = segment
+		cluster.ByHost[segment.Hostname] = append(cluster.ByHost[segment.Hostname], segment)
+		if len(cluster.ByHost[segment.Hostname]) == 1 { // Only add each hostname once
+			cluster.Hostnames = append(cluster.Hostnames, segment.Hostname)
+		}
 	}
-	cluster.Executor = &GPDBExecutor{}
 	return &cluster
 }
 
-func (cluster *Cluster) GenerateSegmentSSHCommand(contentID int, generateCommand func(int) string) []string {
-	cmdStr := generateCommand(contentID)
-	if contentID == -1 {
-		return []string{"bash", "-c", cmdStr}
-	}
-	return ConstructSSHCommand(cluster.GetHostForContent(contentID), cmdStr)
-}
-
-func (cluster *Cluster) GenerateSSHCommandMapForSegments(includeMaster bool, generateCommand func(int) string) map[int][]string {
-	commandMap := make(map[int][]string, len(cluster.ContentIDs))
-	for _, contentID := range cluster.ContentIDs {
-		if contentID == -1 && !includeMaster {
-			continue
+/*
+ * Because cluster commands can be executed either per-segment or per-host, the
+ * "generator" argument to this function can accept one of two types:
+ * - func(int) []string, which takes a content id, for per-segment commands
+ * - func(string) []string, which takes a hostname, for per-host commands
+ * The function uses a type switch to identify the right one, and panics if
+ * an invalid function type is passed in via programmer error.
+ * This method makes it easier for the user to pass in whichever function fits
+ * the kind of command they're generating, as opposed to having to pass in both
+ * content and hostname regardless of scope or using some sort of helper struct.
+ */
+func (cluster *Cluster) GenerateCommandList(scope int, generator interface{}) []ShellCommand {
+	var commands []ShellCommand
+	switch generateCommand := generator.(type) {
+	case func(content int) []string:
+		for _, content := range cluster.ContentIDs {
+			if content == -1 && !scopeIncludesMaster(scope) {
+				continue
+			}
+			commands = append(commands, NewShellCommand(scope, content, "", generateCommand(content)))
 		}
-		commandMap[contentID] = cluster.GenerateSegmentSSHCommand(contentID, generateCommand)
-	}
-	return commandMap
-}
-
-func (cluster *Cluster) GenerateSSHCommandMapForHosts(includeMaster bool, generateCommand func(int) string) map[int][]string {
-	/*
-	 * Derive a list of unique hosts from the cluster and then generate commands
-	 * for each.  If includeMaster is false but there are segments on the master
-	 * host, such as for a single-node cluster, the master host will be included.
-	 */
-	hostSegMap := make(map[string]int, 0)
-	for contentID, seg := range cluster.Segments {
-		if contentID == -1 && !includeMaster {
-			continue
+	case func(host string) []string:
+		for _, host := range cluster.Hostnames {
+			if host == cluster.GetHostForContent(-1) && !scopeIncludesMaster(scope) &&
+				len(cluster.GetContentsForHost(host)) == 1 { // Only exclude the master host if there are no local segments
+				continue
+			}
+			commands = append(commands, NewShellCommand(scope, -2, host, generateCommand(host)))
 		}
-		hostSegMap[seg.Hostname] = contentID
-	}
-	commands := make(map[int][]string, 0)
-	for _, contentID := range hostSegMap {
-		commands[contentID] = cluster.GenerateSegmentSSHCommand(contentID, generateCommand)
+	default:
+		gplog.Fatal(nil, "Generator function passed to GenerateCommandList had an invalid function header.")
 	}
 	return commands
 }
 
-func (cluster *Cluster) GenerateLocalCommandMapForSegments(includeMaster bool, generateCommand func(int) string) map[int][]string {
-	commandMap := make(map[int][]string, len(cluster.ContentIDs))
-	for _, contentID := range cluster.ContentIDs {
-		if contentID == -1 && !includeMaster {
-			continue
-		}
-		cmdStr := generateCommand(contentID)
-		commandMap[contentID] = []string{"bash", "-c", cmdStr}
+func ConstructSSHCommand(useLocal bool, host string, cmd string) []string {
+	if useLocal {
+		return []string{"bash", "-c", cmd}
 	}
-	return commandMap
+	currentUser, _ := operating.System.CurrentUser()
+	user := currentUser.Username
+	return []string{"ssh", "-o", "StrictHostKeyChecking=no", fmt.Sprintf("%s@%s", user, host), cmd}
 }
 
-func (cluster *Cluster) GenerateLocalCommandMapForHosts(includeMaster bool, generateCommand func(int) string) map[int][]string {
-	hostSegMap := make(map[string]int, 0)
-	for contentID, seg := range cluster.Segments {
-		if contentID == -1 && !includeMaster {
-			continue
-		}
-		hostSegMap[seg.Hostname] = contentID
-	}
-	commands := make(map[int][]string, 0)
-	for _, contentID := range hostSegMap {
-		cmdStr := generateCommand(contentID)
-		commands[contentID] = []string{"bash", "-c", cmdStr}
+/*
+ * This function essentially wraps GenerateCommandList such that commands to be
+ * executed on other hosts are sent through SSH and local commands use Bash.
+ */
+func (cluster *Cluster) GenerateSSHCommandList(scope int, generator interface{}) []ShellCommand {
+	var commands []ShellCommand
+	localHost := cluster.GetHostForContent(-1)
+	switch generateCommand := generator.(type) {
+	case func(content int) string:
+		commands = cluster.GenerateCommandList(scope, func(content int) []string {
+			useLocal := (cluster.GetHostForContent(content) == localHost || !scopeIsRemote(scope))
+			cmd := generateCommand(content)
+			return ConstructSSHCommand(useLocal, cluster.GetHostForContent(content), cmd)
+		})
+	case func(host string) string:
+		commands = cluster.GenerateCommandList(scope, func(host string) []string {
+			useLocal := (host == localHost || !scopeIsRemote(scope))
+			cmd := generateCommand(host)
+			return ConstructSSHCommand(useLocal, host, cmd)
+		})
 	}
 	return commands
 }
@@ -160,51 +242,37 @@ func (executor *GPDBExecutor) ExecuteLocalCommand(commandStr string) (string, er
 	return string(output), err
 }
 
-func newRemoteOutput(scope int, numIDs int) *RemoteOutput {
-	stdout := make(map[int]string, numIDs)
-	stderr := make(map[int]string, numIDs)
-	err := make(map[int]error, numIDs)
-	cmdStr := make(map[int]string, numIDs)
-	return &RemoteOutput{Scope: scope, NumErrors: 0, Stdouts: stdout, Stderrs: stderr, Errors: err, CmdStrs: cmdStr}
-}
-
-func (executor *GPDBExecutor) ExecuteClusterCommand(scope int, commandMap map[int][]string) *RemoteOutput {
-	length := len(commandMap)
+/*
+ * This function just executes all of the commands passed to it in parallel; it
+ * doesn't care about the scope of the command except to pass that on to the
+ * RemoteOutput after execution.
+ * TODO: Add batching to prevent bottlenecks when executing in a huge cluster.
+ */
+func (executor *GPDBExecutor) ExecuteClusterCommand(scope int, commandList []ShellCommand) *RemoteOutput {
+	length := len(commandList)
 	finished := make(chan int)
-	contentIDs := make([]int, length)
-	i := 0
-	for key := range commandMap {
-		contentIDs[i] = key
-		i++
-	}
-	output := newRemoteOutput(scope, length)
-	stdouts := make([]string, length)
-	stderrs := make([]string, length)
-	errors := make([]error, length)
-	for i, contentID := range contentIDs {
-		go func(index int, segCommand []string) {
+	numErrors := 0
+	for i := range commandList {
+		go func(index int) {
+			command := commandList[index]
 			var stderr bytes.Buffer
-			cmd := exec.Command(segCommand[0], segCommand[1:]...)
+			cmd := command.Command
 			cmd.Stderr = &stderr
 			out, err := cmd.Output()
-			stdouts[index] = string(out)
-			stderrs[index] = stderr.String()
-			errors[index] = err
+			command.Stdout = string(out)
+			command.Stderr = stderr.String()
+			command.Error = err
+			commandList[index] = command
 			finished <- index
-		}(i, commandMap[contentID])
+		}(i)
 	}
 	for i := 0; i < length; i++ {
 		index := <-finished
-		id := contentIDs[index]
-		output.Stdouts[id] = stdouts[index]
-		output.Stderrs[id] = stderrs[index]
-		output.Errors[id] = errors[index]
-		output.CmdStrs[id] = strings.Join(commandMap[id], " ")
-		if output.Errors[id] != nil {
-			output.NumErrors++
+		if commandList[index].Error != nil {
+			numErrors++
 		}
 	}
-	return output
+	return NewRemoteOutput(scope, numErrors, commandList)
 }
 
 /*
@@ -215,61 +283,30 @@ func (executor *GPDBExecutor) ExecuteClusterCommand(scope int, commandMap map[in
  * 2. shell commands on master to push to remote hosts.
  *    - e.g. running multiple scps on master to push a file to all segments
  */
-func (cluster *Cluster) GenerateAndExecuteCommand(verboseMsg string, execFunc func(contentID int) string, scope int) *RemoteOutput {
+func (cluster *Cluster) GenerateAndExecuteCommand(verboseMsg string, scope int, generator interface{}) *RemoteOutput {
 	gplog.Verbose(verboseMsg)
-	var commandMap map[int][]string
-	switch scope {
-	case ON_SEGMENTS:
-		commandMap = cluster.GenerateSSHCommandMapForSegments(false, execFunc)
-	case ON_SEGMENTS_AND_MASTER:
-		commandMap = cluster.GenerateSSHCommandMapForSegments(true, execFunc)
-	case ON_HOSTS:
-		commandMap = cluster.GenerateSSHCommandMapForHosts(false, execFunc)
-	case ON_HOSTS_AND_MASTER:
-		commandMap = cluster.GenerateSSHCommandMapForHosts(true, execFunc)
-
-	case ON_MASTER_TO_SEGMENTS:
-		commandMap = cluster.GenerateLocalCommandMapForSegments(false, execFunc)
-	case ON_MASTER_TO_SEGMENTS_AND_MASTER:
-		commandMap = cluster.GenerateLocalCommandMapForSegments(true, execFunc)
-	case ON_MASTER_TO_HOSTS:
-		commandMap = cluster.GenerateLocalCommandMapForHosts(false, execFunc)
-	case ON_MASTER_TO_HOSTS_AND_MASTER:
-		commandMap = cluster.GenerateLocalCommandMapForHosts(true, execFunc)
-	default:
-		// If we ever get to this case, it's programmer error, not user error.
-		gplog.Fatal(fmt.Errorf("Invalid remote execution scope for command to %s: %d", strings.ToLower(verboseMsg), scope), "")
-	}
-
-	return cluster.ExecuteClusterCommand(scope, commandMap)
+	commandList := cluster.GenerateSSHCommandList(scope, generator)
+	return cluster.ExecuteClusterCommand(scope, commandList)
 }
 
-func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMsg string, messageFunc func(contentID int) string, noFatal ...bool) {
+func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMsg string, messageFunc interface{}, noFatal ...bool) {
 	if remoteOutput.NumErrors == 0 {
 		return
 	}
-
-	for contentID, err := range remoteOutput.Errors {
-		if err != nil {
-			var dest string
-			hostname := cluster.GetHostForContent(contentID)
-			s := remoteOutput.Scope
-			switch {
-			case s == ON_SEGMENTS || s == ON_SEGMENTS_AND_MASTER:
-				dest += fmt.Sprintf("on segment %d ", contentID)
-				dest += fmt.Sprintf("on host %s", hostname)
-			case s == ON_HOSTS || s == ON_HOSTS_AND_MASTER:
-				dest += fmt.Sprintf("on host %s", hostname)
-			case s == ON_MASTER_TO_SEGMENTS || s == ON_MASTER_TO_SEGMENTS_AND_MASTER:
-				dest += fmt.Sprintf("on master for segment %d ", contentID)
-				dest += fmt.Sprintf("on host %s", hostname)
-			case s == ON_MASTER_TO_HOSTS || s == ON_MASTER_TO_HOSTS_AND_MASTER:
-				dest += fmt.Sprintf("on master for host %s", hostname)
-			}
-			gplog.Verbose("%s %s with error %s: %s", messageFunc(contentID), dest, err, remoteOutput.Stderrs[contentID])
-			gplog.Verbose("Command was: %s", remoteOutput.CmdStrs[contentID])
+	for _, failedCommand := range remoteOutput.FailedCommands {
+		errStr := fmt.Sprintf("with error %s: %s", failedCommand.Error, failedCommand.Stderr)
+		switch getMessage := messageFunc.(type) {
+		case func(content int) string:
+			content := failedCommand.Content
+			host := cluster.GetHostForContent(content)
+			gplog.Verbose("%s on segment %d on host %s %s", getMessage(content), content, host, errStr)
+		case func(host string) string:
+			host := failedCommand.Host
+			gplog.Verbose("%s on host %s %s", getMessage(host), host, errStr)
 		}
+		gplog.Verbose("Command was: %s", failedCommand.CommandString)
 	}
+
 	if len(noFatal) == 1 && noFatal[0] == true {
 		gplog.Error(finalErrMsg)
 	} else {
@@ -279,13 +316,13 @@ func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMs
 
 func LogFatalClusterError(errMessage string, scope int, numErrors int) {
 	str := " on"
-	if scope == ON_MASTER_TO_SEGMENTS || scope == ON_MASTER_TO_SEGMENTS_AND_MASTER || scope == ON_MASTER_TO_HOSTS || scope == ON_MASTER_TO_HOSTS_AND_MASTER {
+	if !scopeIsRemote(scope) {
 		str += " master for"
 	}
 	errMessage += str
 
 	segMsg := "segment"
-	if scope == ON_HOSTS || scope == ON_HOSTS_AND_MASTER || scope == ON_MASTER_TO_HOSTS || scope == ON_MASTER_TO_HOSTS_AND_MASTER {
+	if scopeIsHosts(scope) {
 		segMsg = "host"
 	}
 	if numErrors != 1 {
@@ -294,24 +331,52 @@ func LogFatalClusterError(errMessage string, scope int, numErrors int) {
 	gplog.Fatal(errors.Errorf("%s %d %s. See %s for a complete list of errors.", errMessage, numErrors, segMsg, gplog.GetLogFilePath()), "")
 }
 
-func (cluster *Cluster) GetContentList() []int {
-	return cluster.ContentIDs
-}
-
 func (cluster *Cluster) GetDbidForContent(contentID int) int {
-	return cluster.Segments[contentID].DbID
+	return cluster.ByContent[contentID].DbID
 }
 
 func (cluster *Cluster) GetPortForContent(contentID int) int {
-	return cluster.Segments[contentID].Port
+	return cluster.ByContent[contentID].Port
 }
 
 func (cluster *Cluster) GetHostForContent(contentID int) string {
-	return cluster.Segments[contentID].Hostname
+	return cluster.ByContent[contentID].Hostname
 }
 
 func (cluster *Cluster) GetDirForContent(contentID int) string {
-	return cluster.Segments[contentID].DataDir
+	return cluster.ByContent[contentID].DataDir
+}
+
+func (cluster *Cluster) GetDbidsForHost(hostname string) []int {
+	dbids := make([]int, len(cluster.ByHost[hostname]))
+	for i, seg := range cluster.ByHost[hostname] {
+		dbids[i] = seg.DbID
+	}
+	return dbids
+}
+
+func (cluster *Cluster) GetContentsForHost(hostname string) []int {
+	contents := make([]int, len(cluster.ByHost[hostname]))
+	for i, seg := range cluster.ByHost[hostname] {
+		contents[i] = seg.ContentID
+	}
+	return contents
+}
+
+func (cluster *Cluster) GetPortsForHost(hostname string) []int {
+	ports := make([]int, len(cluster.ByHost[hostname]))
+	for i, seg := range cluster.ByHost[hostname] {
+		ports[i] = seg.Port
+	}
+	return ports
+}
+
+func (cluster *Cluster) GetDirsForHost(hostname string) []string {
+	dirs := make([]string, len(cluster.ByHost[hostname]))
+	for i, seg := range cluster.ByHost[hostname] {
+		dirs[i] = seg.DataDir
+	}
+	return dirs
 }
 
 /*
@@ -358,10 +423,4 @@ func MustGetSegmentConfiguration(connection *dbconn.DBConn) []SegConfig {
 	segConfigs, err := GetSegmentConfiguration(connection)
 	gplog.FatalOnError(err)
 	return segConfigs
-}
-
-func ConstructSSHCommand(host string, cmd string) []string {
-	currentUser, _ := operating.System.CurrentUser()
-	user := currentUser.Username
-	return []string{"ssh", "-o", "StrictHostKeyChecking=no", fmt.Sprintf("%s@%s", user, host), cmd}
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -80,7 +80,7 @@ var _ = Describe("cluster/cluster tests", func() {
 		localSegTwo := []driver.Value{"1", "localhost", "/data/gpseg1"}
 		remoteSegOne := []driver.Value{"2", "remotehost", "/data/gpseg2"}
 
-		It("returns a configuration for a single-host, single-segment cluster", func() {
+		It("returns only primaries for a single-host, single-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...)
 			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
 			results, err := cluster.GetSegmentConfiguration(connection)
@@ -89,7 +89,7 @@ var _ = Describe("cluster/cluster tests", func() {
 			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
 			Expect(results[0].Hostname).To(Equal("localhost"))
 		})
-		It("returns a configuration for a single-host, multi-segment cluster", func() {
+		It("returns only primaries for a single-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...)
 			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
 			results, err := cluster.GetSegmentConfiguration(connection)
@@ -100,10 +100,43 @@ var _ = Describe("cluster/cluster tests", func() {
 			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
 			Expect(results[1].Hostname).To(Equal("localhost"))
 		})
-		It("returns a configuration for a multi-host, multi-segment cluster", func() {
+		It("returns only primaries for a multi-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...).AddRow(remoteSegOne...)
 			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
 			results, err := cluster.GetSegmentConfiguration(connection)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(results)).To(Equal(3))
+			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
+			Expect(results[0].Hostname).To(Equal("localhost"))
+			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
+			Expect(results[1].Hostname).To(Equal("localhost"))
+			Expect(results[2].DataDir).To(Equal("/data/gpseg2"))
+			Expect(results[2].Hostname).To(Equal("remotehost"))
+		})
+		It("returns primaries and mirrors for a single-host, single-segment cluster", func() {
+			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...)
+			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
+			results, err := cluster.GetSegmentConfiguration(connection, true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(results)).To(Equal(1))
+			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
+			Expect(results[0].Hostname).To(Equal("localhost"))
+		})
+		It("returns primaries and mirrors for a single-host, multi-segment cluster", func() {
+			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...)
+			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
+			results, err := cluster.GetSegmentConfiguration(connection, true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(results)).To(Equal(2))
+			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
+			Expect(results[0].Hostname).To(Equal("localhost"))
+			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
+			Expect(results[1].Hostname).To(Equal("localhost"))
+		})
+		It("returns primaries and mirrors for a multi-host, multi-segment cluster", func() {
+			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...).AddRow(remoteSegOne...)
+			mock.ExpectQuery("SELECT (.*)").WillReturnRows(fakeResult)
+			results, err := cluster.GetSegmentConfiguration(connection, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(3))
 			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
@@ -120,7 +153,7 @@ var _ = Describe("cluster/cluster tests", func() {
 		localSegCmd := []string{"bash", "-c", "ls"}
 		remoteSegOneCmd := []string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "ls"}
 		remoteSegTwoCmd := []string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost2", "ls"}
-		DescribeTable("GenerateSSHCommandList with segments", func(scope int, includeMaster bool, numLocalSegments int, numRemoteSegments int) {
+		DescribeTable("GenerateSSHCommandList with segments", func(scope cluster.Scope, includeMaster bool, numLocalSegments int, numRemoteSegments int) {
 			segments := []cluster.SegConfig{masterSeg}
 			var expectedCommands []cluster.ShellCommand
 			if includeMaster {
@@ -149,17 +182,17 @@ var _ = Describe("cluster/cluster tests", func() {
 			})
 			Expect(commandList).To(Equal(expectedCommands))
 		},
-			Entry("Returns a list of ssh commands for the master, including master", cluster.ON_SEGMENTS_AND_MASTER, true, 0, 0),
+			Entry("Returns a list of ssh commands for the master, including master", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, true, 0, 0),
 			Entry("Returns a list of ssh commands for the master, excluding master", cluster.ON_SEGMENTS, false, 0, 0),
-			Entry("Returns a list of ssh commands for one segment, including master", cluster.ON_SEGMENTS_AND_MASTER, true, 0, 1),
+			Entry("Returns a list of ssh commands for one segment, including master", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, true, 0, 1),
 			Entry("Returns a list of ssh commands for one segment, excluding master", cluster.ON_SEGMENTS, false, 0, 1),
-			Entry("Returns a list of ssh commands for two segments on the same host, including master", cluster.ON_SEGMENTS_AND_MASTER, true, 2, 0),
+			Entry("Returns a list of ssh commands for two segments on the same host, including master", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, true, 2, 0),
 			Entry("Returns a list of ssh commands for two segments on the same host, excluding master", cluster.ON_SEGMENTS, false, 2, 0),
-			Entry("Returns a list of ssh commands for three segments on different hosts, including master", cluster.ON_SEGMENTS_AND_MASTER, true, 1, 2),
+			Entry("Returns a list of ssh commands for three segments on different hosts, including master", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, true, 1, 2),
 			Entry("Returns a list of ssh commands for three segments on different hosts, excluding master", cluster.ON_SEGMENTS, false, 1, 2),
 		)
 
-		DescribeTable("GenerateSSHCommandList with hosts", func(scope int, includeMaster bool, numLocalSegments int, numRemoteSegments int) {
+		DescribeTable("GenerateSSHCommandList with hosts", func(scope cluster.Scope, includeMaster bool, numLocalSegments int, numRemoteSegments int) {
 			segments := []cluster.SegConfig{masterSeg}
 			expectedCommands := []cluster.ShellCommand{}
 			if includeMaster {
@@ -189,13 +222,13 @@ var _ = Describe("cluster/cluster tests", func() {
 			})
 			Expect(commandList).To(Equal(expectedCommands))
 		},
-			Entry("returns a list of ssh commands for the master host, including the master host", cluster.ON_HOSTS_AND_MASTER, true, 0, 0),
+			Entry("returns a list of ssh commands for the master host, including the master host", cluster.ON_HOSTS|cluster.INCLUDE_MASTER, true, 0, 0),
 			Entry("returns a list of ssh commands for the master host, excluding the master host", cluster.ON_HOSTS, false, 0, 0),
-			Entry("returns a list of ssh commands for one host, including the master host", cluster.ON_HOSTS_AND_MASTER, true, 0, 1),
+			Entry("returns a list of ssh commands for one host, including the master host", cluster.ON_HOSTS|cluster.INCLUDE_MASTER, true, 0, 1),
 			Entry("returns a list of ssh commands for one host, excluding the master host", cluster.ON_HOSTS, false, 0, 1),
-			Entry("returns a list of ssh commands for one host containing two segments, including the master host", cluster.ON_HOSTS_AND_MASTER, true, 2, 0),
+			Entry("returns a list of ssh commands for one host containing two segments, including the master host", cluster.ON_HOSTS|cluster.INCLUDE_MASTER, true, 2, 0),
 			Entry("returns a list of ssh commands for one host containing two segments, excluding the master host", cluster.ON_HOSTS, false, 2, 0),
-			Entry("returns a list of ssh commands for one local host and two remote hosts, including the master host", cluster.ON_HOSTS_AND_MASTER, true, 0, 2),
+			Entry("returns a list of ssh commands for one local host and two remote hosts, including the master host", cluster.ON_HOSTS|cluster.INCLUDE_MASTER, true, 0, 2),
 			Entry("returns a list of ssh commands for one local host and two remote hosts, excluding the master host", cluster.ON_HOSTS, false, 0, 2),
 		)
 	})
@@ -234,11 +267,11 @@ var _ = Describe("cluster/cluster tests", func() {
 		It("runs commands specified by command slice", func() {
 			testCluster := cluster.Cluster{}
 			commandList := []cluster.ShellCommand{
-				cluster.NewShellCommand(cluster.ON_SEGMENTS_AND_MASTER, -1, "", []string{"touch", "/tmp/gp_common_go_libs_test/foo"}),
-				cluster.NewShellCommand(cluster.ON_SEGMENTS_AND_MASTER, 0, "", []string{"touch", "/tmp/gp_common_go_libs_test/baz"}),
+				cluster.NewShellCommand(cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, -1, "", []string{"touch", "/tmp/gp_common_go_libs_test/foo"}),
+				cluster.NewShellCommand(cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, 0, "", []string{"touch", "/tmp/gp_common_go_libs_test/baz"}),
 			}
 			testCluster.Executor = &cluster.GPDBExecutor{}
-			clusterOutput := testCluster.ExecuteClusterCommand(cluster.ON_SEGMENTS_AND_MASTER, commandList)
+			clusterOutput := testCluster.ExecuteClusterCommand(cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, commandList)
 
 			expectPathToExist("/tmp/gp_common_go_libs_test/foo")
 			expectPathToExist("/tmp/gp_common_go_libs_test/baz")
@@ -248,11 +281,11 @@ var _ = Describe("cluster/cluster tests", func() {
 		It("returns any errors generated by any of the commands", func() {
 			testCluster := cluster.Cluster{}
 			commandList := []cluster.ShellCommand{
-				cluster.NewShellCommand(cluster.ON_SEGMENTS_AND_MASTER, -1, "", []string{"touch", "/tmp/gp_common_go_libs_test/foo"}),
-				cluster.NewShellCommand(cluster.ON_SEGMENTS_AND_MASTER, 0, "", []string{"some-non-existent-command"}),
+				cluster.NewShellCommand(cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, -1, "", []string{"touch", "/tmp/gp_common_go_libs_test/foo"}),
+				cluster.NewShellCommand(cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, 0, "", []string{"some-non-existent-command"}),
 			}
 			testCluster.Executor = &cluster.GPDBExecutor{}
-			clusterOutput := testCluster.ExecuteClusterCommand(cluster.ON_SEGMENTS_AND_MASTER, commandList)
+			clusterOutput := testCluster.ExecuteClusterCommand(cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, commandList)
 
 			expectPathToExist("/tmp/gp_common_go_libs_test/foo")
 			Expect(clusterOutput.NumErrors).To(Equal(1))
@@ -267,7 +300,7 @@ var _ = Describe("cluster/cluster tests", func() {
 		)
 		BeforeEach(func() {
 			failedCmd = cluster.ShellCommand{
-				Scope:         -2, // The appropriate scope will be set in each test
+				Scope:         0, // The appropriate scope will be set in each test
 				Content:       1,
 				Host:          "remotehost1",
 				Command:       nil,
@@ -276,13 +309,13 @@ var _ = Describe("cluster/cluster tests", func() {
 				Error:         errors.Errorf("command error"),
 			}
 			remoteOutput = &cluster.RemoteOutput{
-				Scope:          -2,
+				Scope:          0,
 				NumErrors:      1,
 				Commands:       []cluster.ShellCommand{failedCmd},
 				FailedCommands: []*cluster.ShellCommand{&failedCmd},
 			}
 		})
-		DescribeTable("CheckClusterError", func(scope int, includeMaster bool, perSegment bool, remote bool) {
+		DescribeTable("CheckClusterError", func(scope cluster.Scope, includeMaster bool, perSegment bool, remote bool) {
 			remoteOutput.Scope = scope
 			remoteOutput.Commands[0].Scope = scope
 			remoteOutput.FailedCommands[0].Scope = scope
@@ -303,20 +336,20 @@ var _ = Describe("cluster/cluster tests", func() {
 			defer Expect(logfile).To(gbytes.Say(fmt.Sprintf(`\[DEBUG\]:-Error received on %s with error command error: exit status 1`, debugStr)))
 			testCluster.CheckClusterError(remoteOutput, "Got an error", generatorFunc)
 		},
-			Entry("prints error messages for a per-segment command, including master", cluster.ON_SEGMENTS_AND_MASTER, true, true, true),
+			Entry("prints error messages for a per-segment command, including master", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, true, true, true),
 			Entry("prints error messages for a per-segment command, excluding master", cluster.ON_SEGMENTS, false, true, true),
-			Entry("prints error messages for a per-host command, including the master host", cluster.ON_HOSTS_AND_MASTER, true, false, true),
+			Entry("prints error messages for a per-host command, including the master host", cluster.ON_HOSTS|cluster.INCLUDE_MASTER, true, false, true),
 			Entry("prints error messages for a per-host command, excluding the master host", cluster.ON_HOSTS, false, false, true),
-			Entry("prints error messages for commands executed on master to segments, including master", cluster.ON_MASTER_TO_SEGMENTS_AND_MASTER, true, true, false),
-			Entry("prints error messages for commands executed on master to segments, excluding master", cluster.ON_MASTER_TO_SEGMENTS, false, true, false),
-			Entry("prints error messages for commands executed on master to hosts, including master", cluster.ON_MASTER_TO_HOSTS_AND_MASTER, true, false, false),
-			Entry("prints error messages for commands executed on master to hosts, excluding master", cluster.ON_MASTER_TO_HOSTS, false, false, false),
+			Entry("prints error messages for commands executed on master to segments, including master", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER|cluster.ON_LOCAL, true, true, false),
+			Entry("prints error messages for commands executed on master to segments, excluding master", cluster.ON_SEGMENTS|cluster.ON_LOCAL, false, true, false),
+			Entry("prints error messages for commands executed on master to hosts, including master", cluster.ON_HOSTS|cluster.INCLUDE_MASTER|cluster.ON_LOCAL, true, false, false),
+			Entry("prints error messages for commands executed on master to hosts, excluding master", cluster.ON_HOSTS|cluster.ON_LOCAL, false, false, false),
 		)
 	})
 	Describe("LogFatalClusterError", func() {
 		It("logs an error for 1 segment (with master)", func() {
 			defer testhelper.ShouldPanicWithMessage("Error occurred on 1 segment. See gbytes.Buffer for a complete list of errors.")
-			cluster.LogFatalClusterError("Error occurred", cluster.ON_SEGMENTS_AND_MASTER, 1)
+			cluster.LogFatalClusterError("Error occurred", cluster.ON_SEGMENTS|cluster.INCLUDE_MASTER, 1)
 		})
 		It("logs an error for more than 1 segment", func() {
 			defer testhelper.ShouldPanicWithMessage("Error occurred on 2 segments. See gbytes.Buffer for a complete list of errors.")
@@ -328,58 +361,90 @@ var _ = Describe("cluster/cluster tests", func() {
 		})
 		It("logs an error for more than 1 host (with master)", func() {
 			defer testhelper.ShouldPanicWithMessage("Error occurred on 2 hosts. See gbytes.Buffer for a complete list of errors.")
-			cluster.LogFatalClusterError("Error occurred", cluster.ON_HOSTS_AND_MASTER, 2)
+			cluster.LogFatalClusterError("Error occurred", cluster.ON_HOSTS|cluster.INCLUDE_MASTER, 2)
 		})
 	})
 	Describe("NewCluster", func() {
 		It("sets up the configuration for a single-host, single-segment cluster", func() {
-			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne})
-			Expect(len(cluster.ContentIDs)).To(Equal(2))
-			Expect(len(cluster.Hostnames)).To(Equal(1))
-			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
-			Expect(cluster.GetHostForContent(-1)).To(Equal("localhost"))
-			Expect(cluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
-			Expect(cluster.GetHostForContent(0)).To(Equal("localhost"))
+			newCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne})
+			Expect(len(newCluster.ContentIDs)).To(Equal(2))
+			Expect(len(newCluster.Hostnames)).To(Equal(1))
+			Expect(newCluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
+			Expect(newCluster.GetHostForContent(-1)).To(Equal("localhost"))
+			Expect(newCluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
+			Expect(newCluster.GetHostForContent(0)).To(Equal("localhost"))
 		})
 		It("sets up the configuration for a single-host, multi-segment cluster", func() {
-			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, localSegTwo})
-			Expect(len(cluster.ContentIDs)).To(Equal(3))
-			Expect(len(cluster.Hostnames)).To(Equal(1))
-			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
-			Expect(cluster.GetHostForContent(-1)).To(Equal("localhost"))
-			Expect(cluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
-			Expect(cluster.GetHostForContent(0)).To(Equal("localhost"))
-			Expect(cluster.Segments[2].DataDir).To(Equal("/data/gpseg2"))
-			Expect(cluster.GetHostForContent(2)).To(Equal("localhost"))
+			newCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, localSegTwo})
+			Expect(len(newCluster.ContentIDs)).To(Equal(3))
+			Expect(len(newCluster.Hostnames)).To(Equal(1))
+			Expect(newCluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
+			Expect(newCluster.GetHostForContent(-1)).To(Equal("localhost"))
+			Expect(newCluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
+			Expect(newCluster.GetHostForContent(0)).To(Equal("localhost"))
+			Expect(newCluster.Segments[2].DataDir).To(Equal("/data/gpseg2"))
+			Expect(newCluster.GetHostForContent(2)).To(Equal("localhost"))
 		})
 		It("sets up the configuration for a multi-host, multi-segment cluster", func() {
-			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegTwo})
-			Expect(len(cluster.ContentIDs)).To(Equal(3))
-			Expect(len(cluster.Hostnames)).To(Equal(2))
-			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
-			Expect(cluster.GetHostForContent(-1)).To(Equal("localhost"))
-			Expect(cluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
-			Expect(cluster.GetHostForContent(0)).To(Equal("localhost"))
-			Expect(cluster.Segments[2].DataDir).To(Equal("/data/gpseg3"))
-			Expect(cluster.GetHostForContent(3)).To(Equal("remotehost2"))
+			newCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegTwo})
+			Expect(len(newCluster.ContentIDs)).To(Equal(3))
+			Expect(len(newCluster.Hostnames)).To(Equal(2))
+			Expect(newCluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
+			Expect(newCluster.GetHostForContent(-1)).To(Equal("localhost"))
+			Expect(newCluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
+			Expect(newCluster.GetHostForContent(0)).To(Equal("localhost"))
+			Expect(newCluster.Segments[2].DataDir).To(Equal("/data/gpseg3"))
+			Expect(newCluster.GetHostForContent(3)).To(Equal("remotehost2"))
 		})
 		It("ensures that modifying a segment value in Segments is reflected in ByContent and ByHost", func() {
-			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
-			cluster.Segments[0].DataDir = "/new/dir"
-			Expect(cluster.GetDirForContent(-1)).To(Equal("/new/dir"))
-			Expect(cluster.GetDirsForHost("localhost")[0]).To(Equal("/new/dir"))
+			newCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
+			newCluster.Segments[0].DataDir = "/new/dir"
+			Expect(newCluster.GetDirForContent(-1)).To(Equal("/new/dir"))
+			Expect(newCluster.GetDirsForHost("localhost")[0]).To(Equal("/new/dir"))
 		})
 		It("ensures that modifying a segment value in ByContent is reflected in Segments and ByHost", func() {
-			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
-			cluster.ByContent[-1].DataDir = "/new/dir"
-			Expect(cluster.Segments[0].DataDir).To(Equal("/new/dir"))
-			Expect(cluster.GetDirsForHost("localhost")[0]).To(Equal("/new/dir"))
+			newCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
+			newCluster.ByContent[-1][0].DataDir = "/new/dir"
+			Expect(newCluster.Segments[0].DataDir).To(Equal("/new/dir"))
+			Expect(newCluster.GetDirsForHost("localhost")[0]).To(Equal("/new/dir"))
 		})
 		It("ensures that modifying a segment value in ByHost is reflected in Segments and ByContent", func() {
-			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
-			cluster.ByHost["localhost"][0].DataDir = "/new/dir"
-			Expect(cluster.Segments[0].DataDir).To(Equal("/new/dir"))
-			Expect(cluster.GetDirForContent(-1)).To(Equal("/new/dir"))
+			newCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
+			newCluster.ByHost["localhost"][0].DataDir = "/new/dir"
+			Expect(newCluster.Segments[0].DataDir).To(Equal("/new/dir"))
+			Expect(newCluster.GetDirForContent(-1)).To(Equal("/new/dir"))
+		})
+	})
+	Describe("Accessor functions", func() {
+		var mirrorCluster *cluster.Cluster
+		BeforeEach(func() {
+			primary := cluster.SegConfig{DbID: 2, ContentID: 0, Port: 20000, Hostname: "localhost", DataDir: "/data/primary/gpseg0"}
+			mirror := cluster.SegConfig{DbID: 3, ContentID: 0, Port: 21000, Hostname: "otherhost", DataDir: "/data/mirror/gpseg0"}
+			mirrorCluster = cluster.NewCluster([]cluster.SegConfig{masterSeg, primary, mirror})
+		})
+		It("returns primary information for a segment by default", func() {
+			Expect(mirrorCluster.GetDbidForContent(0)).To(Equal(2))
+			Expect(mirrorCluster.GetPortForContent(0)).To(Equal(20000))
+			Expect(mirrorCluster.GetHostForContent(0)).To(Equal("localhost"))
+			Expect(mirrorCluster.GetDirForContent(0)).To(Equal("/data/primary/gpseg0"))
+		})
+		It("returns primary information for a segment if primary information is requested", func() {
+			Expect(mirrorCluster.GetDbidForContent(0, "p")).To(Equal(2))
+			Expect(mirrorCluster.GetPortForContent(0, "p")).To(Equal(20000))
+			Expect(mirrorCluster.GetHostForContent(0, "p")).To(Equal("localhost"))
+			Expect(mirrorCluster.GetDirForContent(0, "p")).To(Equal("/data/primary/gpseg0"))
+		})
+		It("returns mirror information for a segment if mirror information is requested", func() {
+			Expect(mirrorCluster.GetDbidForContent(0, "m")).To(Equal(3))
+			Expect(mirrorCluster.GetPortForContent(0, "m")).To(Equal(21000))
+			Expect(mirrorCluster.GetHostForContent(0, "m")).To(Equal("otherhost"))
+			Expect(mirrorCluster.GetDirForContent(0, "m")).To(Equal("/data/mirror/gpseg0"))
+		})
+		It("returns information for a host", func() {
+			Expect(mirrorCluster.GetDbidsForHost("localhost")).To(Equal([]int{1, 2}))
+			Expect(mirrorCluster.GetContentsForHost("localhost")).To(Equal([]int{-1, 0}))
+			Expect(mirrorCluster.GetPortsForHost("localhost")).To(Equal([]int{5432, 20000}))
+			Expect(mirrorCluster.GetDirsForHost("localhost")).To(Equal([]string{"/data/gpseg-1", "/data/primary/gpseg0"}))
 		})
 	})
 })

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 )
@@ -64,8 +65,12 @@ var _ = Describe("cluster/cluster tests", func() {
 		testCluster.Executor = testExecutor
 	})
 	Describe("ConstructSSHCommand", func() {
-		It("constructs an ssh command", func() {
-			cmd := cluster.ConstructSSHCommand("some-host", "ls")
+		It("constructs a local ssh command", func() {
+			cmd := cluster.ConstructSSHCommand(true, "some-host", "ls")
+			Expect(cmd).To(Equal([]string{"bash", "-c", "ls"}))
+		})
+		It("constructs a remote ssh command", func() {
+			cmd := cluster.ConstructSSHCommand(false, "some-host", "ls")
 			Expect(cmd).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@some-host", "ls"}))
 		})
 	})
@@ -109,209 +114,90 @@ var _ = Describe("cluster/cluster tests", func() {
 			Expect(results[2].Hostname).To(Equal("remotehost"))
 		})
 	})
-	Describe("GenerateSSHCommandMapForSegments", func() {
-		It("Returns a map of ssh commands for the master, including master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
-			commandMap := testCluster.GenerateSSHCommandMapForSegments(true, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(1))
-			Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "ls"}))
-		})
-		It("Returns a map of ssh commands for the master, excluding master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
-			commandMap := testCluster.GenerateSSHCommandMapForSegments(false, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(0))
-		})
-		It("Returns a map of ssh commands for one segment, including master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, remoteSegOne})
-			commandMap := testCluster.GenerateSSHCommandMapForSegments(true, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(2))
-			Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "ls"}))
-			Expect(commandMap[1]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "ls"}))
-		})
-		It("Returns a map of ssh commands for one segment, excluding master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, remoteSegOne})
-			commandMap := testCluster.GenerateSSHCommandMapForSegments(false, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(1))
-			Expect(commandMap[1]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "ls"}))
-		})
-		It("Returns a map of ssh commands for two segments on the same host, including master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, localSegTwo})
-			commandMap := testCluster.GenerateSSHCommandMapForSegments(true, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(3))
-			Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "ls"}))
-			Expect(commandMap[0]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "ls"}))
-			Expect(commandMap[2]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "ls"}))
-		})
-		It("Returns a map of ssh commands for two segments on the same host, excluding master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, localSegTwo})
-			commandMap := testCluster.GenerateSSHCommandMapForSegments(false, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(2))
-			Expect(commandMap[0]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "ls"}))
-			Expect(commandMap[2]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "ls"}))
-		})
-		It("Returns a map of ssh commands for three segments on different hosts, including master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne, remoteSegTwo})
-			commandMap := testCluster.GenerateSSHCommandMapForSegments(true, func(contentID int) string {
-				return fmt.Sprintf("echo %d", contentID)
-			})
-			Expect(len(commandMap)).To(Equal(4))
-			Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "echo -1"}))
-			Expect(commandMap[0]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "echo 0"}))
-			Expect(commandMap[1]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "echo 1"}))
-			Expect(commandMap[3]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost2", "echo 3"}))
-		})
-		It("Returns a map of ssh commands for three segments on different hosts, excluding master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne, remoteSegTwo})
-			commandMap := testCluster.GenerateSSHCommandMapForSegments(false, func(contentID int) string {
-				return fmt.Sprintf("echo %d", contentID)
-			})
-			Expect(len(commandMap)).To(Equal(3))
-			Expect(commandMap[0]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "echo 0"}))
-			Expect(commandMap[1]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "echo 1"}))
-			Expect(commandMap[3]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost2", "echo 3"}))
-		})
-	})
-	Describe("GenerateSSHCommandMapForHosts", func() {
-		It("Returns a map of ssh commands for the master host, including the master host", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
-			commandMap := testCluster.GenerateSSHCommandMapForHosts(true, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(1))
-			Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "ls"}))
-		})
-		It("Returns a map of ssh commands for the master host, excluding the master host", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
-			commandMap := testCluster.GenerateSSHCommandMapForHosts(false, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(0))
-		})
-		It("Returns a map of ssh commands for one host, including the master host", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{remoteSegOne})
-			commandMap := testCluster.GenerateSSHCommandMapForHosts(true, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(1))
-			Expect(commandMap[1]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "ls"}))
-		})
-		It("Returns a map of ssh commands for one host, excluding the master host", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{remoteSegOne})
-			commandMap := testCluster.GenerateSSHCommandMapForHosts(false, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(1))
-			Expect(commandMap[1]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "ls"}))
-		})
-		It("Returns a map of ssh commands for one host containing two segments, including the master host", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne})
-			commandMap := testCluster.GenerateSSHCommandMapForHosts(true, func(_ int) string {
-				return "ls"
-			})
-			Expect(len(commandMap)).To(Equal(1))
-			// Either -1 or 0 will be present, but which content isn't guaranteed since we only really care about the host
-			if _, ok := commandMap[-1]; ok {
-				Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "ls"}))
-			} else {
-				Expect(commandMap[0]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "ls"}))
+
+	Describe("GenerateSSHCommandList", func() {
+		masterSegCmd := []string{"bash", "-c", "ls"}
+		localSegCmd := []string{"bash", "-c", "ls"}
+		remoteSegOneCmd := []string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "ls"}
+		remoteSegTwoCmd := []string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost2", "ls"}
+		DescribeTable("GenerateSSHCommandList with segments", func(scope int, includeMaster bool, numLocalSegments int, numRemoteSegments int) {
+			segments := []cluster.SegConfig{masterSeg}
+			var expectedCommands []cluster.ShellCommand
+			if includeMaster {
+				expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, -1, "", masterSegCmd))
 			}
-		})
-		It("Returns a map of ssh commands for one host containing two segments, excluding the master host", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne})
-			commandMap := testCluster.GenerateSSHCommandMapForHosts(false, func(_ int) string {
+			if numLocalSegments >= 1 {
+				segments = append(segments, localSegOne)
+				expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, 0, "", localSegCmd))
+			}
+			if numLocalSegments >= 2 {
+				segments = append(segments, localSegTwo)
+				expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, 2, "", localSegCmd))
+			}
+			if numRemoteSegments >= 1 {
+				segments = append(segments, remoteSegOne)
+				expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, 1, "", remoteSegOneCmd))
+			}
+			if numRemoteSegments >= 2 {
+				segments = append(segments, remoteSegTwo)
+				expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, 3, "", remoteSegTwoCmd))
+			}
+
+			testCluster := cluster.NewCluster(segments)
+			commandList := testCluster.GenerateSSHCommandList(scope, func(_ int) string {
 				return "ls"
 			})
-			Expect(len(commandMap)).To(Equal(1))
-			Expect(commandMap[0]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "ls"}))
-		})
-		It("Returns a map of ssh commands for one master host and two remote hosts, including the master host", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne, remoteSegTwo})
-			commandMap := testCluster.GenerateSSHCommandMapForHosts(true, func(contentID int) string {
-				return fmt.Sprintf("echo %d", contentID)
-			})
-			Expect(len(commandMap)).To(Equal(3))
-			// Either -1 or 0 will be present, but which content isn't guaranteed since we only really care about the host
-			if _, ok := commandMap[-1]; ok {
-				Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "echo -1"}))
-			} else {
-				Expect(commandMap[0]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "echo 0"}))
+			Expect(commandList).To(Equal(expectedCommands))
+		},
+			Entry("Returns a list of ssh commands for the master, including master", cluster.ON_SEGMENTS_AND_MASTER, true, 0, 0),
+			Entry("Returns a list of ssh commands for the master, excluding master", cluster.ON_SEGMENTS, false, 0, 0),
+			Entry("Returns a list of ssh commands for one segment, including master", cluster.ON_SEGMENTS_AND_MASTER, true, 0, 1),
+			Entry("Returns a list of ssh commands for one segment, excluding master", cluster.ON_SEGMENTS, false, 0, 1),
+			Entry("Returns a list of ssh commands for two segments on the same host, including master", cluster.ON_SEGMENTS_AND_MASTER, true, 2, 0),
+			Entry("Returns a list of ssh commands for two segments on the same host, excluding master", cluster.ON_SEGMENTS, false, 2, 0),
+			Entry("Returns a list of ssh commands for three segments on different hosts, including master", cluster.ON_SEGMENTS_AND_MASTER, true, 1, 2),
+			Entry("Returns a list of ssh commands for three segments on different hosts, excluding master", cluster.ON_SEGMENTS, false, 1, 2),
+		)
+
+		DescribeTable("GenerateSSHCommandList with hosts", func(scope int, includeMaster bool, numLocalSegments int, numRemoteSegments int) {
+			segments := []cluster.SegConfig{masterSeg}
+			expectedCommands := []cluster.ShellCommand{}
+			if includeMaster {
+				expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, -2, "localhost", masterSegCmd))
 			}
-			Expect(commandMap[1]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "echo 1"}))
-			Expect(commandMap[3]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost2", "echo 3"}))
-		})
-		It("Returns a map of ssh commands for one master host and two remote hosts, excluding the master host", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne, remoteSegTwo})
-			commandMap := testCluster.GenerateSSHCommandMapForHosts(false, func(contentID int) string {
-				return fmt.Sprintf("echo %d", contentID)
-			})
-			Expect(len(commandMap)).To(Equal(3))
-			Expect(commandMap[0]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@localhost", "echo 0"}))
-			Expect(commandMap[1]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost1", "echo 1"}))
-			Expect(commandMap[3]).To(Equal([]string{"ssh", "-o", "StrictHostKeyChecking=no", "testUser@remotehost2", "echo 3"}))
-		})
-	})
-	Describe("GenerateLocalCommandMapForSegments", func() {
-		It("Returns a map of local commands for one segment, including master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, remoteSegOne})
-			commandMap := testCluster.GenerateLocalCommandMapForSegments(true, func(id int) string {
-				return fmt.Sprintf("echo %d", id)
-			})
-			Expect(len(commandMap)).To(Equal(2))
-			Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "echo -1"}))
-			Expect(commandMap[1]).To(Equal([]string{"bash", "-c", "echo 1"}))
-		})
-		It("Returns a map of local commands for one segment, excluding master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, remoteSegOne})
-			commandMap := testCluster.GenerateLocalCommandMapForSegments(false, func(id int) string {
-				return fmt.Sprintf("echo %d", id)
-			})
-			Expect(len(commandMap)).To(Equal(1))
-			Expect(commandMap[1]).To(Equal([]string{"bash", "-c", "echo 1"}))
-		})
-	})
-	Describe("GenerateLocalCommandMapForHosts", func() {
-		It("Returns a map of local commands for hosts, including master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{localSegOne, masterSeg, remoteSegOne, remoteSegTwo})
-			commandMap := testCluster.GenerateLocalCommandMapForHosts(true, func(id int) string {
-				return fmt.Sprintf("echo %d", id)
-			})
-			Expect(len(commandMap)).To(Equal(3))
-			// Either -1 or 0 will be present, but which content isn't guaranteed since we only really care about the host
-			if _, ok := commandMap[-1]; ok {
-				Expect(commandMap[-1]).To(Equal([]string{"bash", "-c", "echo -1"}))
-			} else {
-				Expect(commandMap[0]).To(Equal([]string{"bash", "-c", "echo 0"}))
+			if numLocalSegments >= 1 {
+				segments = append(segments, localSegOne)
+				if !includeMaster {
+					expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, -2, "localhost", localSegCmd))
+				}
 			}
-			Expect(commandMap[1]).To(Equal([]string{"bash", "-c", "echo 1"}))
-			Expect(commandMap[3]).To(Equal([]string{"bash", "-c", "echo 3"}))
-		})
-		It("Returns a map of local commands for hosts, excluding master", func() {
-			testCluster := cluster.NewCluster([]cluster.SegConfig{localSegOne, localSegTwo, masterSeg, remoteSegOne, remoteSegTwo})
-			commandMap := testCluster.GenerateLocalCommandMapForHosts(false, func(id int) string {
-				return fmt.Sprintf("echo %d", id)
-			})
-			Expect(len(commandMap)).To(Equal(3))
-			// Either 2 or 0 will be present, but which content isn't guaranteed since we only really care about the host
-			if _, ok := commandMap[2]; ok {
-				Expect(commandMap[2]).To(Equal([]string{"bash", "-c", "echo 2"}))
-			} else {
-				Expect(commandMap[0]).To(Equal([]string{"bash", "-c", "echo 0"}))
+			if numLocalSegments >= 2 {
+				segments = append(segments, localSegTwo)
 			}
-			Expect(commandMap[1]).To(Equal([]string{"bash", "-c", "echo 1"}))
-			Expect(commandMap[3]).To(Equal([]string{"bash", "-c", "echo 3"}))
-		})
+			if numRemoteSegments >= 1 {
+				segments = append(segments, remoteSegOne)
+				expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, -2, "remotehost1", remoteSegOneCmd))
+			}
+			if numRemoteSegments >= 2 {
+				segments = append(segments, remoteSegTwo)
+				expectedCommands = append(expectedCommands, cluster.NewShellCommand(scope, -2, "remotehost2", remoteSegTwoCmd))
+			}
+
+			testCluster := cluster.NewCluster(segments)
+			commandList := testCluster.GenerateSSHCommandList(scope, func(_ string) string {
+				return "ls"
+			})
+			Expect(commandList).To(Equal(expectedCommands))
+		},
+			Entry("returns a list of ssh commands for the master host, including the master host", cluster.ON_HOSTS_AND_MASTER, true, 0, 0),
+			Entry("returns a list of ssh commands for the master host, excluding the master host", cluster.ON_HOSTS, false, 0, 0),
+			Entry("returns a list of ssh commands for one host, including the master host", cluster.ON_HOSTS_AND_MASTER, true, 0, 1),
+			Entry("returns a list of ssh commands for one host, excluding the master host", cluster.ON_HOSTS, false, 0, 1),
+			Entry("returns a list of ssh commands for one host containing two segments, including the master host", cluster.ON_HOSTS_AND_MASTER, true, 2, 0),
+			Entry("returns a list of ssh commands for one host containing two segments, excluding the master host", cluster.ON_HOSTS, false, 2, 0),
+			Entry("returns a list of ssh commands for one local host and two remote hosts, including the master host", cluster.ON_HOSTS_AND_MASTER, true, 0, 2),
+			Entry("returns a list of ssh commands for one local host and two remote hosts, excluding the master host", cluster.ON_HOSTS, false, 0, 2),
+		)
 	})
 	Describe("ExecuteLocalCommand", func() {
 		BeforeEach(func() {
@@ -345,143 +231,87 @@ var _ = Describe("cluster/cluster tests", func() {
 		AfterEach(func() {
 			os.RemoveAll("/tmp/gp_common_go_libs_test")
 		})
-		It("runs commands specified by command map", func() {
+		It("runs commands specified by command slice", func() {
 			testCluster := cluster.Cluster{}
-			commandMap := map[int][]string{
-				-1: {"touch", "/tmp/gp_common_go_libs_test/foo"},
-				0:  {"touch", "/tmp/gp_common_go_libs_test/baz"},
+			commandList := []cluster.ShellCommand{
+				cluster.NewShellCommand(cluster.ON_SEGMENTS_AND_MASTER, -1, "", []string{"touch", "/tmp/gp_common_go_libs_test/foo"}),
+				cluster.NewShellCommand(cluster.ON_SEGMENTS_AND_MASTER, 0, "", []string{"touch", "/tmp/gp_common_go_libs_test/baz"}),
 			}
 			testCluster.Executor = &cluster.GPDBExecutor{}
-			testCluster.ExecuteClusterCommand(cluster.ON_SEGMENTS_AND_MASTER, commandMap)
+			clusterOutput := testCluster.ExecuteClusterCommand(cluster.ON_SEGMENTS_AND_MASTER, commandList)
 
 			expectPathToExist("/tmp/gp_common_go_libs_test/foo")
 			expectPathToExist("/tmp/gp_common_go_libs_test/baz")
+			Expect(clusterOutput.NumErrors).To(Equal(0))
+			Expect(len(clusterOutput.FailedCommands)).To(Equal(0))
 		})
 		It("returns any errors generated by any of the commands", func() {
 			testCluster := cluster.Cluster{}
-			commandMap := map[int][]string{
-				-1: {"touch", "/tmp/gp_common_go_libs_test/foo"},
-				0:  {"some-non-existent-command"},
+			commandList := []cluster.ShellCommand{
+				cluster.NewShellCommand(cluster.ON_SEGMENTS_AND_MASTER, -1, "", []string{"touch", "/tmp/gp_common_go_libs_test/foo"}),
+				cluster.NewShellCommand(cluster.ON_SEGMENTS_AND_MASTER, 0, "", []string{"some-non-existent-command"}),
 			}
 			testCluster.Executor = &cluster.GPDBExecutor{}
-			clusterOutput := testCluster.ExecuteClusterCommand(cluster.ON_SEGMENTS_AND_MASTER, commandMap)
+			clusterOutput := testCluster.ExecuteClusterCommand(cluster.ON_SEGMENTS_AND_MASTER, commandList)
 
 			expectPathToExist("/tmp/gp_common_go_libs_test/foo")
 			Expect(clusterOutput.NumErrors).To(Equal(1))
-			Expect(clusterOutput.Errors[0].Error()).To(Equal("exec: \"some-non-existent-command\": executable file not found in $PATH"))
+			Expect(len(clusterOutput.FailedCommands)).To(Equal(1))
+			Expect(clusterOutput.FailedCommands[0].Error.Error()).To(Equal("exec: \"some-non-existent-command\": executable file not found in $PATH"))
 		})
 	})
 	Describe("CheckClusterError", func() {
 		var (
-			remoteOutput         *cluster.RemoteOutput
-			remoteOutputOnMaster *cluster.RemoteOutput
+			remoteOutput *cluster.RemoteOutput
+			failedCmd    cluster.ShellCommand
 		)
 		BeforeEach(func() {
+			failedCmd = cluster.ShellCommand{
+				Scope:         -2, // The appropriate scope will be set in each test
+				Content:       1,
+				Host:          "remotehost1",
+				Command:       nil,
+				CommandString: "this is the command",
+				Stderr:        "exit status 1",
+				Error:         errors.Errorf("command error"),
+			}
 			remoteOutput = &cluster.RemoteOutput{
-				NumErrors: 1,
-				Stderrs: map[int]string{
-					1: "exit status 1",
-				},
-				Errors: map[int]error{
-					1: errors.Errorf("ssh error"),
-				},
-				CmdStrs: map[int]string{
-					1: "this is the command",
-				},
+				Scope:          -2,
+				NumErrors:      1,
+				Commands:       []cluster.ShellCommand{failedCmd},
+				FailedCommands: []*cluster.ShellCommand{&failedCmd},
 			}
-			remoteOutputOnMaster = &cluster.RemoteOutput{
-				NumErrors: 1,
-				Stderrs: map[int]string{
-					1: "exit status 1",
-				},
-				Errors: map[int]error{
-					1: errors.Errorf("scp error"),
-				},
-				CmdStrs: map[int]string{
-					1: "scp </master_dir/test/file> <host/seg dest path>",
-				},
+		})
+		DescribeTable("CheckClusterError", func(scope int, includeMaster bool, perSegment bool, remote bool) {
+			remoteOutput.Scope = scope
+			remoteOutput.Commands[0].Scope = scope
+			remoteOutput.FailedCommands[0].Scope = scope
+			errStr := "1 segment"
+			debugStr := "segment 1 on host remotehost1"
+			var generatorFunc interface{}
+			generatorFunc = func(contentID int) string { return "Error received" }
+			if !perSegment {
+				errStr = "1 host"
+				debugStr = "host remotehost1"
+				generatorFunc = func(host string) string { return "Error received" }
 			}
-
-		})
-		It("prints error messages for a command executed on a per-segment basis", func() {
-			remoteOutput.Scope = cluster.ON_SEGMENTS
-
-			defer testhelper.ShouldPanicWithMessage("Got an error on 1 segment. See gbytes.Buffer for a complete list of errors.")
+			if !remote {
+				errStr = "master for " + errStr
+			}
+			defer testhelper.ShouldPanicWithMessage(fmt.Sprintf("Got an error on %s. See gbytes.Buffer for a complete list of errors.", errStr))
 			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Command was: this is the command`))
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error received on segment 1 on host remotehost1 with error ssh error: exit status 1`))
-			testCluster.CheckClusterError(remoteOutput, "Got an error", func(contentID int) string {
-				return "Error received"
-			})
-		})
-		It("prints error messages for a command executed on a per-segment basis", func() {
-			remoteOutput.Scope = cluster.ON_SEGMENTS_AND_MASTER
-
-			defer testhelper.ShouldPanicWithMessage("Got an error on 1 segment. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Command was: this is the command`))
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error received on segment 1 on host remotehost1 with error ssh error: exit status 1`))
-			testCluster.CheckClusterError(remoteOutput, "Got an error", func(contentID int) string {
-				return "Error received"
-			})
-		})
-		It("prints error messages for a command executed on a per-host basis", func() {
-			remoteOutput.Scope = cluster.ON_HOSTS
-
-			defer testhelper.ShouldPanicWithMessage("Got an error on 1 host. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error received on host remotehost1 with error ssh error: exit status 1`))
-			testCluster.CheckClusterError(remoteOutput, "Got an error", func(contentID int) string {
-				return "Error received"
-			})
-		})
-		It("prints error messages for a command executed on a per-host and master basis", func() {
-			remoteOutput.Scope = cluster.ON_HOSTS_AND_MASTER
-
-			defer testhelper.ShouldPanicWithMessage("Got an error on 1 host. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error received on host remotehost1 with error ssh error: exit status 1`))
-			testCluster.CheckClusterError(remoteOutput, "Got an error", func(contentID int) string {
-				return "Error received"
-			})
-		})
-		It("prints error messages for per-segment commands executed on master to segments", func() {
-			remoteOutputOnMaster.Scope = cluster.ON_MASTER_TO_SEGMENTS
-
-			defer testhelper.ShouldPanicWithMessage("Got an error on master for 1 segment. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Command was: scp </master_dir/test/file> <host/seg dest path>`))
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error occurred on master for segment 1 on host remotehost1 with error scp error: exit status 1`))
-			testCluster.CheckClusterError(remoteOutputOnMaster, "Got an error", func(contentID int) string {
-				return "Error occurred"
-			})
-		})
-		It("prints error messages for per-segment commands executed on master to segments and on master itself", func() {
-			remoteOutputOnMaster.Scope = cluster.ON_MASTER_TO_SEGMENTS_AND_MASTER
-
-			defer testhelper.ShouldPanicWithMessage("Got an error on master for 1 segment. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Command was: scp </master_dir/test/file> <host/seg dest path>`))
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error occurred on master for segment 1 on host remotehost1 with error scp error: exit status 1`))
-			testCluster.CheckClusterError(remoteOutputOnMaster, "Got an error", func(contentID int) string {
-				return "Error occurred"
-			})
-		})
-		It("prints error messages for per-host commands executed on master to hosts", func() {
-			remoteOutputOnMaster.Scope = cluster.ON_MASTER_TO_HOSTS
-
-			defer testhelper.ShouldPanicWithMessage("Got an error on master for 1 host. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Command was: scp </master_dir/test/file> <host/seg dest path>`))
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error occurred on master for host remotehost1 with error scp error: exit status 1`))
-			testCluster.CheckClusterError(remoteOutputOnMaster, "Got an error", func(contentID int) string {
-				return "Error occurred"
-			})
-		})
-		It("prints error messages for per-host commands executed on master to hosts and on master itself", func() {
-			remoteOutputOnMaster.Scope = cluster.ON_MASTER_TO_HOSTS_AND_MASTER
-
-			defer testhelper.ShouldPanicWithMessage("Got an error on master for 1 host. See gbytes.Buffer for a complete list of errors.")
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Command was: scp </master_dir/test/file> <host/seg dest path>`))
-			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Error occurred on master for host remotehost1 with error scp error: exit status 1`))
-
-			testCluster.CheckClusterError(remoteOutputOnMaster, "Got an error", func(contentID int) string {
-				return "Error occurred"
-			})
-		})
+			defer Expect(logfile).To(gbytes.Say(fmt.Sprintf(`\[DEBUG\]:-Error received on %s with error command error: exit status 1`, debugStr)))
+			testCluster.CheckClusterError(remoteOutput, "Got an error", generatorFunc)
+		},
+			Entry("prints error messages for a per-segment command, including master", cluster.ON_SEGMENTS_AND_MASTER, true, true, true),
+			Entry("prints error messages for a per-segment command, excluding master", cluster.ON_SEGMENTS, false, true, true),
+			Entry("prints error messages for a per-host command, including the master host", cluster.ON_HOSTS_AND_MASTER, true, false, true),
+			Entry("prints error messages for a per-host command, excluding the master host", cluster.ON_HOSTS, false, false, true),
+			Entry("prints error messages for commands executed on master to segments, including master", cluster.ON_MASTER_TO_SEGMENTS_AND_MASTER, true, true, false),
+			Entry("prints error messages for commands executed on master to segments, excluding master", cluster.ON_MASTER_TO_SEGMENTS, false, true, false),
+			Entry("prints error messages for commands executed on master to hosts, including master", cluster.ON_MASTER_TO_HOSTS_AND_MASTER, true, false, false),
+			Entry("prints error messages for commands executed on master to hosts, excluding master", cluster.ON_MASTER_TO_HOSTS, false, false, false),
+		)
 	})
 	Describe("LogFatalClusterError", func() {
 		It("logs an error for 1 segment (with master)", func() {
@@ -501,34 +331,55 @@ var _ = Describe("cluster/cluster tests", func() {
 			cluster.LogFatalClusterError("Error occurred", cluster.ON_HOSTS_AND_MASTER, 2)
 		})
 	})
-	Describe("cluster setup and accessor functions", func() {
-		It("returns content dir for a single-host, single-segment cluster", func() {
+	Describe("NewCluster", func() {
+		It("sets up the configuration for a single-host, single-segment cluster", func() {
 			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne})
-			Expect(len(cluster.GetContentList())).To(Equal(2))
-			Expect(cluster.Segments[-1].DataDir).To(Equal("/data/gpseg-1"))
+			Expect(len(cluster.ContentIDs)).To(Equal(2))
+			Expect(len(cluster.Hostnames)).To(Equal(1))
+			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
 			Expect(cluster.GetHostForContent(-1)).To(Equal("localhost"))
-			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg0"))
+			Expect(cluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
 			Expect(cluster.GetHostForContent(0)).To(Equal("localhost"))
 		})
 		It("sets up the configuration for a single-host, multi-segment cluster", func() {
 			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, localSegTwo})
-			Expect(len(cluster.GetContentList())).To(Equal(3))
-			Expect(cluster.Segments[-1].DataDir).To(Equal("/data/gpseg-1"))
+			Expect(len(cluster.ContentIDs)).To(Equal(3))
+			Expect(len(cluster.Hostnames)).To(Equal(1))
+			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
 			Expect(cluster.GetHostForContent(-1)).To(Equal("localhost"))
-			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg0"))
+			Expect(cluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
 			Expect(cluster.GetHostForContent(0)).To(Equal("localhost"))
 			Expect(cluster.Segments[2].DataDir).To(Equal("/data/gpseg2"))
 			Expect(cluster.GetHostForContent(2)).To(Equal("localhost"))
 		})
 		It("sets up the configuration for a multi-host, multi-segment cluster", func() {
 			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegTwo})
-			Expect(len(cluster.GetContentList())).To(Equal(3))
-			Expect(cluster.Segments[-1].DataDir).To(Equal("/data/gpseg-1"))
+			Expect(len(cluster.ContentIDs)).To(Equal(3))
+			Expect(len(cluster.Hostnames)).To(Equal(2))
+			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg-1"))
 			Expect(cluster.GetHostForContent(-1)).To(Equal("localhost"))
-			Expect(cluster.Segments[0].DataDir).To(Equal("/data/gpseg0"))
+			Expect(cluster.Segments[1].DataDir).To(Equal("/data/gpseg0"))
 			Expect(cluster.GetHostForContent(0)).To(Equal("localhost"))
-			Expect(cluster.Segments[3].DataDir).To(Equal("/data/gpseg3"))
+			Expect(cluster.Segments[2].DataDir).To(Equal("/data/gpseg3"))
 			Expect(cluster.GetHostForContent(3)).To(Equal("remotehost2"))
+		})
+		It("ensures that modifying a segment value in Segments is reflected in ByContent and ByHost", func() {
+			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
+			cluster.Segments[0].DataDir = "/new/dir"
+			Expect(cluster.GetDirForContent(-1)).To(Equal("/new/dir"))
+			Expect(cluster.GetDirsForHost("localhost")[0]).To(Equal("/new/dir"))
+		})
+		It("ensures that modifying a segment value in ByContent is reflected in Segments and ByHost", func() {
+			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
+			cluster.ByContent[-1].DataDir = "/new/dir"
+			Expect(cluster.Segments[0].DataDir).To(Equal("/new/dir"))
+			Expect(cluster.GetDirsForHost("localhost")[0]).To(Equal("/new/dir"))
+		})
+		It("ensures that modifying a segment value in ByHost is reflected in Segments and ByContent", func() {
+			cluster := cluster.NewCluster([]cluster.SegConfig{masterSeg})
+			cluster.ByHost["localhost"][0].DataDir = "/new/dir"
+			Expect(cluster.Segments[0].DataDir).To(Equal("/new/dir"))
+			Expect(cluster.GetDirForContent(-1)).To(Equal("/new/dir"))
 		})
 	})
 })

--- a/testhelper/structs.go
+++ b/testhelper/structs.go
@@ -54,7 +54,7 @@ func (executor *TestExecutor) ExecuteLocalCommand(commandStr string) (string, er
 	return executor.LocalOutput, nil
 }
 
-func (executor *TestExecutor) ExecuteClusterCommand(scope int, commandList []cluster.ShellCommand) *cluster.RemoteOutput {
+func (executor *TestExecutor) ExecuteClusterCommand(scope cluster.Scope, commandList []cluster.ShellCommand) *cluster.RemoteOutput {
 	executor.NumExecutions++
 	executor.ClusterCommands = append(executor.ClusterCommands, commandList)
 	if executor.ErrorOnExecNum == 0 || executor.NumExecutions == executor.ErrorOnExecNum {

--- a/testhelper/structs.go
+++ b/testhelper/structs.go
@@ -40,7 +40,7 @@ type TestExecutor struct {
 	LocalError      error
 	LocalCommands   []string
 	ClusterOutput   *cluster.RemoteOutput
-	ClusterCommands []map[int][]string
+	ClusterCommands [][]cluster.ShellCommand
 	ErrorOnExecNum  int // Throw the specified error after this many executions of Execute[...]Command(); 0 means always return error
 	NumExecutions   int
 }
@@ -54,9 +54,9 @@ func (executor *TestExecutor) ExecuteLocalCommand(commandStr string) (string, er
 	return executor.LocalOutput, nil
 }
 
-func (executor *TestExecutor) ExecuteClusterCommand(scope int, commandMap map[int][]string) *cluster.RemoteOutput {
+func (executor *TestExecutor) ExecuteClusterCommand(scope int, commandList []cluster.ShellCommand) *cluster.RemoteOutput {
 	executor.NumExecutions++
-	executor.ClusterCommands = append(executor.ClusterCommands, commandMap)
+	executor.ClusterCommands = append(executor.ClusterCommands, commandList)
 	if executor.ErrorOnExecNum == 0 || executor.NumExecutions == executor.ErrorOnExecNum {
 		return executor.ClusterOutput
 	}


### PR DESCRIPTION
This is a fairly extensive PR that makes large refactors to several aspects of Cluster and its command execution functions:
- Change per-host execution to not be a hack on top of per-segment execution
- Improve the way sets of commands and their outputs are stored
- Add support for mirror configuration in Cluster
- Simplify scope handling with bitmasking

See the individual commit messages for more details.

Note that this PR **does break the existing API** in several areas, but the actual changes required on the utility side should be fairly small (mostly changing scope variables passed into  `ExecuteClusterCommand` and tweaking generator functions to use hostnames instead of `GetHostForContent`) and by putting all the breaking commits into one PR they should hopefully be easier to deal with.