### PR TITLE
recursive structmatcher

### DIFF
--- a/structmatcher/structmatcher.go
+++ b/structmatcher/structmatcher.go
@@ -41,8 +41,8 @@ func StructMatcher(expected interface{}, actual interface{}, shouldFilter bool, 
 	mismatches := []string{}
 	mismatches = append(mismatches, InterceptGomegaFailures(func() {
 		for i := 0; i < expectedStruct.NumField(); i++ {
-			expectedField := expectedStruct.Field(i)
-			actualField := actualStruct.Field(i)
+			expectedField := reflect.Indirect(expectedStruct.Field(i))
+			actualField := reflect.Indirect(actualStruct.Field(i))
 			fieldName := actualStruct.Type().Field(i).Name
 			// If we're including, skip this field if the name doesn't match; if we're excluding, skip if it does match
 			if shouldFilter && ((filterInclude && !filterMap[fieldName]) || (!filterInclude && filterMap[fieldName])) {
@@ -57,6 +57,10 @@ func StructMatcher(expected interface{}, actual interface{}, shouldFilter bool, 
 					actualStructField := actualStruct.Field(i).Index(j).Interface()
 					mismatches = append(mismatches, StructMatcher(expectedStructField, actualStructField, shouldFilter, filterInclude, nestedFilterFields...)...)
 				}
+			} else if actualField.Kind() == reflect.Struct {
+				expectedStructField := expectedStruct.Field(i).Interface()
+				actualStructField := actualStruct.Field(i).Interface()
+				mismatches = append(mismatches, StructMatcher(expectedStructField, actualStructField, shouldFilter, filterInclude, nestedFilterFields...)...)
 			} else {
 				expectedValue := expectedStruct.Field(i).Interface()
 				actualValue := actualStruct.Field(i).Interface()

--- a/structmatcher/structmatcher_test.go
+++ b/structmatcher/structmatcher_test.go
@@ -23,6 +23,8 @@ var _ = Describe("structmatcher.StructMatchers", func() {
 		Field1      int
 		Field2      string
 		NestedSlice []SimpleStruct
+		Struct      SimpleStruct
+		PtrStruct   *SimpleStruct
 	}
 	Describe("structmatcher.StructMatcher", func() {
 		It("returns no failures for the same structs", func() {
@@ -77,6 +79,22 @@ var _ = Describe("structmatcher.StructMatchers", func() {
 			mismatches := structmatcher.StructMatcher(&struct1, &struct2, true, false, "NestedSlice.Field1")
 			Expect(len(mismatches)).To(Equal(1))
 			Expect(mismatches[0]).To(Equal("Mismatch on field Field2\nExpected\n    <string>: teststruct2\nto equal\n    <string>: message1"))
+		})
+		It("returns mismatches in nested structs", func() {
+			struct1 := NestedStruct{Struct: SimpleStruct{Field1: 7}}
+			struct2 := NestedStruct{Struct: SimpleStruct{Field1: 8}}
+			mismatches := structmatcher.StructMatcher(&struct1, &struct2, false, false)
+			Expect(len(mismatches)).To(Equal(1))
+			// TODO: would be better if this was "Mismatch on field Struct1.Field1..."
+			Expect(mismatches[0]).To(Equal("Mismatch on field Field1\nExpected\n    <int>: 8\nto equal\n    <int>: 7"))
+		})
+		It("returns mismatches in nested pointers to structs", func() {
+			struct1 := NestedStruct{PtrStruct: &SimpleStruct{Field1: 7}}
+			struct2 := NestedStruct{PtrStruct: &SimpleStruct{Field1: 8}}
+			mismatches := structmatcher.StructMatcher(&struct1, &struct2, false, false)
+			Expect(len(mismatches)).To(Equal(1))
+			// TODO: would be better if this was "Mismatch on field Struct1.Field1..."
+			Expect(mismatches[0]).To(Equal("Mismatch on field Field1\nExpected\n    <int>: 8\nto equal\n    <int>: 7"))
 		})
 	})
 

--- a/structmatcher/structmatcher_test.go
+++ b/structmatcher/structmatcher_test.go
@@ -50,7 +50,7 @@ var _ = Describe("structmatcher.StructMatchers", func() {
 			struct2 := NestedStruct{Field1: 0, Field2: "message1", NestedSlice: []SimpleStruct{{Field1: 4}}}
 			mismatches := structmatcher.StructMatcher(&struct1, &struct2, false, false)
 			Expect(len(mismatches)).To(Equal(1))
-			Expect(mismatches[0]).To(Equal("Mismatch on field Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"))
+			Expect(mismatches[0]).To(Equal("Mismatch on field NestedSlice[0].Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"))
 		})
 		It("returns mismatches including struct fields", func() {
 			struct1 := NestedStruct{Field1: 0, Field2: "message1", NestedSlice: []SimpleStruct{{Field1: 3}}}
@@ -64,14 +64,14 @@ var _ = Describe("structmatcher.StructMatchers", func() {
 			struct2 := NestedStruct{Field1: 0, Field2: "teststruct2", NestedSlice: []SimpleStruct{{Field1: 4}}}
 			mismatches := structmatcher.StructMatcher(&struct1, &struct2, true, true, "NestedSlice.Field1")
 			Expect(len(mismatches)).To(Equal(1))
-			Expect(mismatches[0]).To(Equal("Mismatch on field Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"))
+			Expect(mismatches[0]).To(Equal("Mismatch on field NestedSlice[0].Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"))
 		})
 		It("returns mismatches excluding struct fields", func() {
 			struct1 := NestedStruct{Field1: 0, Field2: "message1", NestedSlice: []SimpleStruct{{Field1: 3}}}
 			struct2 := NestedStruct{Field1: 0, Field2: "teststruct2", NestedSlice: []SimpleStruct{{Field1: 4}}}
 			mismatches := structmatcher.StructMatcher(&struct1, &struct2, true, false, "Field2")
 			Expect(len(mismatches)).To(Equal(1))
-			Expect(mismatches[0]).To(Equal("Mismatch on field Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"))
+			Expect(mismatches[0]).To(Equal("Mismatch on field NestedSlice[0].Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"))
 		})
 		It("returns mismatches excluding nested struct slice fields", func() {
 			struct1 := NestedStruct{Field1: 0, Field2: "message1", NestedSlice: []SimpleStruct{{Field1: 3}}}
@@ -85,16 +85,14 @@ var _ = Describe("structmatcher.StructMatchers", func() {
 			struct2 := NestedStruct{Struct: SimpleStruct{Field1: 8}}
 			mismatches := structmatcher.StructMatcher(&struct1, &struct2, false, false)
 			Expect(len(mismatches)).To(Equal(1))
-			// TODO: would be better if this was "Mismatch on field Struct1.Field1..."
-			Expect(mismatches[0]).To(Equal("Mismatch on field Field1\nExpected\n    <int>: 8\nto equal\n    <int>: 7"))
+			Expect(mismatches[0]).To(Equal("Mismatch on field Struct.Field1\nExpected\n    <int>: 8\nto equal\n    <int>: 7"))
 		})
 		It("returns mismatches in nested pointers to structs", func() {
 			struct1 := NestedStruct{PtrStruct: &SimpleStruct{Field1: 7}}
 			struct2 := NestedStruct{PtrStruct: &SimpleStruct{Field1: 8}}
 			mismatches := structmatcher.StructMatcher(&struct1, &struct2, false, false)
 			Expect(len(mismatches)).To(Equal(1))
-			// TODO: would be better if this was "Mismatch on field Struct1.Field1..."
-			Expect(mismatches[0]).To(Equal("Mismatch on field Field1\nExpected\n    <int>: 8\nto equal\n    <int>: 7"))
+			Expect(mismatches[0]).To(Equal("Mismatch on field PtrStruct.Field1\nExpected\n    <int>: 8\nto equal\n    <int>: 7"))
 		})
 	})
 
@@ -123,7 +121,7 @@ var _ = Describe("structmatcher.StructMatchers", func() {
 			messages := InterceptGomegaFailures(func() {
 				Expect(struct2).To(structmatcher.MatchStruct(struct1))
 			})
-			Expect(messages).To(Equal([]string{"Expected structs to match but:\nMismatch on field Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"}))
+			Expect(messages).To(Equal([]string{"Expected structs to match but:\nMismatch on field NestedSlice[0].Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"}))
 		})
 		It("returns mismatches including struct fields", func() {
 			struct1 := NestedStruct{Field1: 0, Field2: "message1", NestedSlice: []SimpleStruct{{Field1: 3}}}
@@ -139,7 +137,7 @@ var _ = Describe("structmatcher.StructMatchers", func() {
 			messages := InterceptGomegaFailures(func() {
 				Expect(struct2).To(structmatcher.MatchStruct(struct1).IncludingFields("NestedSlice.Field1"))
 			})
-			Expect(messages).To(Equal([]string{"Expected structs to match but:\nMismatch on field Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"}))
+			Expect(messages).To(Equal([]string{"Expected structs to match but:\nMismatch on field NestedSlice[0].Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"}))
 		})
 		It("returns mismatches excluding struct fields", func() {
 			struct1 := NestedStruct{Field1: 0, Field2: "message1", NestedSlice: []SimpleStruct{{Field1: 3}}}
@@ -147,7 +145,7 @@ var _ = Describe("structmatcher.StructMatchers", func() {
 			messages := InterceptGomegaFailures(func() {
 				Expect(struct2).To(structmatcher.MatchStruct(struct1).ExcludingFields("Field2"))
 			})
-			Expect(messages).To(Equal([]string{"Expected structs to match but:\nMismatch on field Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"}))
+			Expect(messages).To(Equal([]string{"Expected structs to match but:\nMismatch on field NestedSlice[0].Field1\nExpected\n    <int>: 4\nto equal\n    <int>: 3"}))
 		})
 		It("returns mismatches excluding nested struct slice fields", func() {
 			struct1 := NestedStruct{Field1: 0, Field2: "message1", NestedSlice: []SimpleStruct{{Field1: 3}}}


### PR DESCRIPTION
This could potentially break some existing tests if they look at individual messages, but that seems an unlikely way to use structmatcher.