### PR TITLE
Fix gofmt detectecd error found during `make test`.

### DIFF
--- a/structmatcher/structmatcher.go
+++ b/structmatcher/structmatcher.go
@@ -119,7 +119,7 @@ func (m *Matcher) Match(actual interface{}) (success bool, err error) {
 
 func (m *Matcher) FailureMessage(actual interface{}) (message string) {
 	//return format.Message(actual, "to match struct", m.expected)
-	return "Expected structs to match but:\n"+strings.Join(m.mismatches, "\n")
+	return "Expected structs to match but:\n" + strings.Join(m.mismatches, "\n")
 }
 
 func (m *Matcher) NegatedFailureMessage(actual interface{}) (message string) {


### PR DESCRIPTION
The `gp-common-go-libs` pipeline executing `! gofmt -l structmatcher/ | read` during the `lint` make target has identified this as a failure. This update corrects the failure.

This was introduced with https://github.com/greenplum-db/gp-common-go-libs/commit/7f408d257e14cc8eefdfc111deea7cd930e29c17