### PR TITLE
Fix catalog version query on dbconn initialization

### DIFF
--- a/dbconn/version.go
+++ b/dbconn/version.go
@@ -31,7 +31,7 @@ func NewVersion(versionStr string) GPDBVersion {
 }
 
 func InitializeVersion(dbconn *DBConn) (dbversion GPDBVersion, err error) {
-	err = dbconn.Get(&dbversion, "SELECT version() AS versionstring")
+	err = dbconn.Get(&dbversion, "SELECT pg_catalog.version() AS versionstring")
 	if err != nil {
 		return
 	}

--- a/testhelper/functions.go
+++ b/testhelper/functions.go
@@ -67,7 +67,7 @@ func CreateMockDBConn() (*dbconn.DBConn, sqlmock.Sqlmock) {
 
 func ExpectVersionQuery(mock sqlmock.Sqlmock, versionStr string) {
 	versionRow := sqlmock.NewRows([]string{"versionstring"}).AddRow(fmt.Sprintf("(Greenplum Database %s)", versionStr))
-	mock.ExpectQuery(regexp.QuoteMeta("SELECT version() AS versionstring")).WillReturnRows(versionRow)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT pg_catalog.version() AS versionstring")).WillReturnRows(versionRow)
 }
 
 func CreateAndConnectMockDB(numConns int) (*dbconn.DBConn, sqlmock.Sqlmock) {


### PR DESCRIPTION
Database connection version intialization will fail to return the
catalog version if other schemas containing a `version()` function is
referenced first in the search path. Fully qualify the version function
call to ensure pg_catalog's version is returned.

Authored-by: Kevin Yeap <kyeap@pivotal.io>