### PR TITLE
cluster: Prevent panic when executing commands

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -209,6 +209,7 @@ func NewCluster(segConfigs []SegConfig) *Cluster {
 	cluster.Segments = segConfigs
 	cluster.ByContent = make(map[int][]*SegConfig, 0)
 	cluster.ByHost = make(map[string][]*SegConfig, 0)
+	cluster.Executor = &GPDBExecutor{}
 	for i := range cluster.Segments {
 		segment := &cluster.Segments[i]
 		cluster.ContentIDs = append(cluster.ContentIDs, segment.ContentID)


### PR DESCRIPTION
The cluster.Executor should be set when newing up a cluster object.

Authored-by: Oliver Albertini <oalbertini@pivotal.io>