### PR TITLE
structmatcher: Use MatchStruct matcher in deprecated implementations

### DIFF
--- a/structmatcher/structmatcher.go
+++ b/structmatcher/structmatcher.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"strings"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 )
@@ -106,26 +105,17 @@ func structMatcher(expected, actual reflect.Value, fieldPath string, shouldFilte
 
 // Deprecated: Use structmatcher.MatchStruct() GomegaMatcher
 func ExpectStructsToMatch(expected interface{}, actual interface{}) {
-	mismatches := StructMatcher(expected, actual, false, false)
-	if len(mismatches) > 0 {
-		Fail(strings.Join(mismatches, "\n"))
-	}
+	Expect(actual).To(MatchStruct(expected))
 }
 
 // Deprecated: Use structmatcher.MatchStruct().ExcludingFields() GomegaMatcher
 func ExpectStructsToMatchExcluding(expected interface{}, actual interface{}, excludeFields ...string) {
-	mismatches := StructMatcher(expected, actual, true, false, excludeFields...)
-	if len(mismatches) > 0 {
-		Fail(strings.Join(mismatches, "\n"))
-	}
+	Expect(actual).To(MatchStruct(expected).ExcludingFields(excludeFields...))
 }
 
 // Deprecated: Use structmatcher.MatchStruct().IncludingFields() GomegaMatcher
 func ExpectStructsToMatchIncluding(expected interface{}, actual interface{}, includeFields ...string) {
-	mismatches := StructMatcher(expected, actual, true, true, includeFields...)
-	if len(mismatches) > 0 {
-		Fail(strings.Join(mismatches, "\n"))
-	}
+	Expect(actual).To(MatchStruct(expected).IncludingFields(includeFields...))
 }
 
 type Matcher struct {


### PR DESCRIPTION
We're trying to upgrade to ginkgo/v2, but structmatcher imports ginkgo v1. We can avoid the issue by not importing ginkgo at all. In this case, structmatcher only called Fail() in the deprecated ExpectXxx() functions. These can be replaced with using the MatchStruct() GomegaMatcher.

More info: https://github.com/onsi/ginkgo/issues/875