### PR TITLE
dbconn: add the ability to connect in utility mode

### DIFF
--- a/testhelper/functions.go
+++ b/testhelper/functions.go
@@ -53,9 +53,12 @@ func SetDBVersion(connection *dbconn.DBConn, versionStr string) {
 	connection.Version = dbconn.NewVersion(versionStr)
 }
 
-func CreateMockDBConn() (*dbconn.DBConn, sqlmock.Sqlmock) {
+func CreateMockDBConn(errs ...error) (*dbconn.DBConn, sqlmock.Sqlmock) {
 	mockdb, mock := CreateMockDB()
-	driver := TestDriver{DB: mockdb, DBName: "testdb", User: "testrole"}
+	driver := &TestDriver{DB: mockdb, DBName: "testdb", User: "testrole"}
+	if len(errs) > 0 {
+		driver.ErrsToReturn = errs
+	}
 	connection := dbconn.NewDBConnFromEnvironment("testdb")
 	connection.Driver = driver
 	connection.Host = "testhost"

--- a/testhelper/structs.go
+++ b/testhelper/structs.go
@@ -10,14 +10,21 @@ import (
 )
 
 type TestDriver struct {
-	ErrToReturn error
-	DB          *sqlx.DB
-	DBName      string
-	User        string
+	ErrToReturn  error
+	ErrsToReturn []error
+	DB           *sqlx.DB
+	DBName       string
+	User         string
+	CallNumber   int
 }
 
-func (driver TestDriver) Connect(driverName string, dataSourceName string) (*sqlx.DB, error) {
-	if driver.ErrToReturn != nil {
+func (driver *TestDriver) Connect(driverName string, dataSourceName string) (*sqlx.DB, error) {
+	if driver.ErrsToReturn != nil && driver.CallNumber < len(driver.ErrsToReturn) {
+		// Return the errors in the order specified until we run out of specified errors, then return normally
+		err := driver.ErrsToReturn[driver.CallNumber]
+		driver.CallNumber++
+		return nil, err
+	} else if driver.ErrToReturn != nil {
 		return nil, driver.ErrToReturn
 	}
 	return driver.DB, nil


### PR DESCRIPTION
This commit modifies the dbconn.Connect function to take a boolean
which, if set to true, connects in utility mode.  It also adds some
helper functions for more explicit invocation.

In order to test this functionality, it was necessary to modify the
TestDriver struct to be able to return different errors on different
calls, so this commit also makes that change.