### PR TITLE
add ssl support

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -193,7 +193,8 @@ func (dbconn *DBConn) Connect(numConns int) error {
 	if krbsrvname == "" {
 		krbsrvname = "postgres"
 	}
-	connStr := fmt.Sprintf(`user='%s' dbname='%s' krbsrvname='%s' host=%s port=%d sslmode=disable`, user, dbname, krbsrvname, dbconn.Host, dbconn.Port)
+	connStr := fmt.Sprintf(`user='%s' dbname='%s' krbsrvname='%s' host=%s port=%d`, user, dbname, krbsrvname, dbconn.Host, dbconn.Port)
+
 	dbconn.ConnPool = make([]*sqlx.DB, numConns)
 	for i := 0; i < numConns; i++ {
 		conn, err := dbconn.Driver.Connect("postgres", connStr)


### PR DESCRIPTION
Ssl connection is supported by this version of lib/pq it used. But in gp-common-go-libs, when connect to gpdb, sslmode is set to disable in hard code. 

We want it to read sslmode from the environment variable. Just remove the hard code `sslmode="disable"` will work.

