### PR TITLE
Add gplog.FatalNoPanicLogStacktrace()

### DIFF
--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -81,6 +81,8 @@ const (
  *          cannot be reached.  This function will exit the program after printing
  *          the error message.
  * - FatalWithoutPanic: Same as Fatal, but will not trigger panic. Just exit(1).
+ * - FatalWithoutPanicLogStacktrace(): Same as FatalWithoutPanic, but
+ *          writes the stacktrace into the log file for debug purpose.
  */
 type LogPrefixFunc func(string) string
 type LogFileNameFunc func(string, string) string
@@ -322,6 +324,37 @@ func FatalWithoutPanic(s string, v ...interface{}) {
 	_ = logger.logFile.Output(1, message)
 	_ = logger.logStderr.Output(1, message)
 	exitFunc()
+}
+
+func FatalWithoutPanicLogStacktrace(err error, output ...string){
+	if err != nil {
+		var outputStr string
+		if len(output) == 0 {
+			outputStr = ""
+		} else {
+			outputStr = output[0]
+		}
+		logMutex.Lock()
+		defer logMutex.Unlock()
+		message := GetLogPrefix("CRITICAL")
+		errorCode = 2
+		stackTraceStr := ""
+		if err != nil {
+			message += fmt.Sprintf("%v", err)
+			stackTraceStr = formatStackTrace(errors.WithStack(err))
+			if outputStr != "" {
+				message += ": "
+			}
+		}
+		message += strings.TrimSpace(fmt.Sprintf(outputStr))
+		_ = logger.logFile.Output(1, message+stackTraceStr)
+		if logger.shellVerbosity >= LOGVERBOSE {
+			_ = logger.logStderr.Output(1, message + stackTraceStr)
+		} else {
+			_ = logger.logStderr.Output(1,message)
+		}
+		exitFunc()
+	}
 }
 
 type stackTracer interface {

--- a/gplog/gplog_test.go
+++ b/gplog/gplog_test.go
@@ -509,6 +509,23 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(logfile, fatalExpected+expectedMessage)
 				})
 			})
+			Context("FatalWithoutPanicLogStacktrace", func() {
+				It("prints to the log file with stack trace, then exit(1)", func() {
+					gplog.SetExitFunc(func() {})
+					expectedMessage := "logfile error something wrong"
+					err := errors.WithStack(errors.New(expectedMessage))
+					expectedWithStack := `.*\[CRITICAL\]:-logfile error something wrong
+.*gplog_test\.glob.*
+.*gplog_test\.go.*
+.*
+.*internal\/suite.go.*
+runtime\.goexit.*`
+					gplog.FatalWithoutPanicLogStacktrace(err, "")
+					testhelper.NotExpectRegexp(stdout, fatalExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, fatalExpected+expectedMessage)
+					Expect(string(logfile.Contents())).To(MatchRegexp(expectedWithStack))
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
 This function does not call panic() but still writes the stack trace into the log file, 
 so that the user has it for debugging purposes even if he is configured not to print it into the console. 
 This is the variation of FatalWithNoPanic(), which also does not call panic(), but swallows the stack trace.