### PR TITLE
Change uses of "master" to "coordinator"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,5 @@ set-prod:
 	fly --target prod set-pipeline --check-creds \
 	--pipeline=gp-common-go-libs \
 	-c ci/pipeline.yml \
-	--var=branch=master \
+	--var=branch=main\
 	--var=golang-version=${GOLANG_VERSION}


### PR DESCRIPTION
As part of an effort to use more inclusive terminology, GPDB 7 is renaming the GPDB "master" to the "coordinator" and the "master" branch to "main", and any related code is to be changed as well.

This commit adds new INCLUDE_COORDINATOR and EXCLUDE_COORDINATOR scopes as synonyms of the existing INCLUDE_MASTER and EXCLUDE_MASTER scopes, instead of renaming them, to maintain backwards compatibility for now. All internal usage of the term is updated, however.