### PR TITLE
support kerberos and sslmode prefer

### DIFF
--- a/dbconn/dbconn.go
+++ b/dbconn/dbconn.go
@@ -257,7 +257,7 @@ func (dbconn *DBConn) Connect(numConns int, utilityMode ...bool) error {
 			gplog.Verbose("Failed to connect with sslmode=require, trying sslmode=disable")
 			// overwrite sslmode as disable
 			connStr = connStr + " sslmode=disable"
-			conn, err = dbconn.Driver.Connect("postgres", connStr)
+			conn, err = dbconn.Driver.Connect("pgx", connStr)
 		}
 		err = dbconn.handleConnectionError(err)
 		if err != nil {


### PR DESCRIPTION
1.  add `krbsrvname` to connect string.
     The application should RegisterGSSProvider() for pgx if it need support kerberos.
2. set default sslmode as `prefer`.  
3. use another connect string format to handle user name like `xxx/host@domain`

Co-authored-by: xiaoxiaoHe-E 
Co-authored-by: Adam Lee <adlee@vmware.com>
