### PR TITLE
Introducing API GetSegmentConfigurationFromFile() for configuration retrieval from file

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -46,12 +46,16 @@ type Cluster struct {
 }
 
 type SegConfig struct {
-	DbID      int
-	ContentID int
-	Role      string
-	Port      int
-	Hostname  string
-	DataDir   string
+	DbID          int
+	ContentID     int
+	Role          string
+	PreferredRole string
+	Mode          string
+	Status        string
+	Port          int
+	Hostname      string
+	Address       string
+	DataDir       string
 }
 
 /*
@@ -522,8 +526,12 @@ SELECT
 	s.dbid,
 	s.content as contentid,
 	s.role,
+	s.preferred_role as preferredrole,
+	s.mode,
+	s.status,
 	s.port,
 	s.hostname,
+	s.address,
 	e.fselocation as datadir
 FROM gp_segment_configuration s
 JOIN pg_filespace_entry e ON s.dbid = e.fsedbid
@@ -542,8 +550,12 @@ SELECT
 	dbid,
 	content as contentid,
 	role,
+	preferred_role as preferredrole,
+	mode,
+	status,
 	port,
 	hostname,
+	address,
 	datadir
 FROM gp_segment_configuration
 %s

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -76,10 +76,14 @@ var _ = Describe("cluster/cluster tests", func() {
 		})
 	})
 	Describe("GetSegmentConfiguration", func() {
-		header := []string{"contentid", "hostname", "datadir"}
-		localSegOne := []driver.Value{"0", "localhost", "/data/gpseg0"}
-		localSegTwo := []driver.Value{"1", "localhost", "/data/gpseg1"}
-		remoteSegOne := []driver.Value{"2", "remotehost", "/data/gpseg2"}
+		header := []string{"dbid", "contentid", "role", "preferredrole", "mode", "status", "port", "hostname", "address", "datadir"}
+		localSegOneValue := cluster.SegConfig{1, 0, "p", "p", "s", "u", 6002, "localhost", "127.0.0.1", "/data/gpseg0"}
+		localSegTwoValue := cluster.SegConfig{2, 1, "m", "m", "s", "u", 6003, "localhost", "127.0.0.1", "/data/gpseg1"}
+		remoteSegOneValue := cluster.SegConfig{3, 2, "p", "m", "s", "u", 6004, "remotehost", "127.0.0.1", "/data/gpseg2"}
+
+		localSegOne := []driver.Value{localSegOneValue.DbID, localSegOneValue.ContentID, localSegOneValue.Role, localSegOneValue.PreferredRole, localSegOneValue.Mode, localSegOneValue.Status, localSegOneValue.Port, localSegOneValue.Hostname, localSegOneValue.Address, localSegOneValue.DataDir}
+		localSegTwo := []driver.Value{localSegTwoValue.DbID, localSegTwoValue.ContentID, localSegTwoValue.Role, localSegTwoValue.PreferredRole, localSegTwoValue.Mode, localSegTwoValue.Status, localSegTwoValue.Port, localSegTwoValue.Hostname, localSegTwoValue.Address, localSegTwoValue.DataDir}
+		remoteSegOne := []driver.Value{remoteSegOneValue.DbID, remoteSegOneValue.ContentID, remoteSegOneValue.Role, remoteSegOneValue.PreferredRole, remoteSegOneValue.Mode, remoteSegOneValue.Status, remoteSegOneValue.Port, remoteSegOneValue.Hostname, remoteSegOneValue.Address, remoteSegOneValue.DataDir}
 
 		It("returns only primaries for a single-host, single-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...)
@@ -87,8 +91,7 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(1))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
 		})
 		It("returns only primaries for a single-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...)
@@ -96,10 +99,8 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(2))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
-			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
-			Expect(results[1].Hostname).To(Equal("localhost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
+			Expect(results[1]).To(Equal(localSegTwoValue))
 		})
 		It("returns only primaries for a multi-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...).AddRow(remoteSegOne...)
@@ -107,12 +108,9 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(3))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
-			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
-			Expect(results[1].Hostname).To(Equal("localhost"))
-			Expect(results[2].DataDir).To(Equal("/data/gpseg2"))
-			Expect(results[2].Hostname).To(Equal("remotehost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
+			Expect(results[1]).To(Equal(localSegTwoValue))
+			Expect(results[2]).To(Equal(remoteSegOneValue))
 		})
 		It("returns primaries and mirrors for a single-host, single-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...)
@@ -120,8 +118,7 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(1))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
 		})
 		It("returns primaries and mirrors for a single-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...)
@@ -129,10 +126,8 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(2))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
-			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
-			Expect(results[1].Hostname).To(Equal("localhost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
+			Expect(results[1]).To(Equal(localSegTwoValue))
 		})
 		It("returns primaries and mirrors for a multi-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...).AddRow(remoteSegOne...)
@@ -140,12 +135,9 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(3))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
-			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
-			Expect(results[1].Hostname).To(Equal("localhost"))
-			Expect(results[2].DataDir).To(Equal("/data/gpseg2"))
-			Expect(results[2].Hostname).To(Equal("remotehost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
+			Expect(results[1]).To(Equal(localSegTwoValue))
+			Expect(results[2]).To(Equal(remoteSegOneValue))
 		})
 		It("returns mirrors for a single-host, single-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...)
@@ -153,8 +145,7 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection, true, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(1))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
 		})
 		It("returns mirrors for a single-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...)
@@ -162,10 +153,8 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection, true, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(2))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
-			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
-			Expect(results[1].Hostname).To(Equal("localhost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
+			Expect(results[1]).To(Equal(localSegTwoValue))
 		})
 		It("returns mirrors for a multi-host, multi-segment cluster", func() {
 			fakeResult := sqlmock.NewRows(header).AddRow(localSegOne...).AddRow(localSegTwo...).AddRow(remoteSegOne...)
@@ -173,12 +162,9 @@ var _ = Describe("cluster/cluster tests", func() {
 			results, err := cluster.GetSegmentConfiguration(connection, true, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(results)).To(Equal(3))
-			Expect(results[0].DataDir).To(Equal("/data/gpseg0"))
-			Expect(results[0].Hostname).To(Equal("localhost"))
-			Expect(results[1].DataDir).To(Equal("/data/gpseg1"))
-			Expect(results[1].Hostname).To(Equal("localhost"))
-			Expect(results[2].DataDir).To(Equal("/data/gpseg2"))
-			Expect(results[2].Hostname).To(Equal("remotehost"))
+			Expect(results[0]).To(Equal(localSegOneValue))
+			Expect(results[1]).To(Equal(localSegTwoValue))
+			Expect(results[2]).To(Equal(remoteSegOneValue))
 		})
 	})
 


### PR DESCRIPTION
This PR introduces an API GetSegmentConfigurationFromFile() to parse the gpsegconfig_dump file to retrieve segment configuration information.
The recommended use of the API is to get the contents of gp_segment_configuration when the database is down.

In the realm of gpdb, the gpsegconfig_dump file holds the crucial segment configuration information. this file is generated in the coordinator
data directory through the fts process. gpsegconfig_dump is always in sync with gp_segment_configuration as on each fts probe the file
gets updated if there is any change in the segment configuration. Various fts gucs govern the frequency of writing to this file.

Note: Since the gpsegconfig_dump file is updated by fts process the information returned by
this function can be a bit stale since the user can configure fts to run less frequently

The gpsegconfig_dump file follows a structured format, as illustrated in the example below:
```
1 -1 p p n u 6000 localhost localhost /data/temp1
2 0 p p n u 6002 localhost localhost /data/temp2
3 1 p p n u 6003 localhost localhost /data/temp3
4 2 p p n u 6004 localhost localhost /data/temp4
```

Example Usage:
```
   segments, err := GetSegmentConfigurationFromFile("/path/to/coordinator/data/dir")
   if err != nil {
       //Handle error
       return
   }
   
```
*. if gpsegconfig_dump has the following content ( with data-dir).
```
   1 -1 p p n u 6000 localhost localhost /data/qddir
   2 0 p p n u 6002 localhost localhost /data/seg1
```
   SegConfig will have the DataDir field populated
*. gpsegconfig_dump has the following content ( without data-dir)
```
    1 -1 p p n u 6000 localhost localhost
    2 0 p p n u 6002 localhost localhost
```
    SegConfig will have the DataDir field empty

The structured data, captured in the gpsegconfig_dump file, is now accessible through the newly added API GetSegmentConfigurationFromFile().
This enhancement helps the other utilities to perform some operations even if the database is offline.

e.g.
In gpsupport utility if the database is down we can use this API to retrieve the data dirs to perform a log collection.
or
In gpdeletesystem if the database is down the API can be used to perform the database cleanup still.

The reason to add it in gp-common-go-libs is that this is the growing API library that is being used by almost all the newly created gp modern utilities like project spine/ gpdr/ gpupgrade/ gpbackup/gprestore.

Added test cases to do the unit testing around the following scenario
when the file is valid it should provide valid results.
when the file is invalid it should fail in parsing or reading it.
added test cases to cover old and new field counts of gpsegconfig_dump. 
when the user passes the wrong coordinatorDataDir argument. 
