### PR TITLE
Add new Progress command for gplog

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -466,7 +466,7 @@ var _ = Describe("cluster/cluster tests", func() {
 			testCluster.Executor = &cluster.GPDBExecutor{}
 			output, err := testCluster.ExecuteLocalCommand(commandStr)
 
-			Expect(output).To(Equal("bash: some-non-existent-command: command not found\n"))
+			Expect(output).To(ContainSubstring("some-non-existent-command: command not found\n"))
 			Expect(err.Error()).To(Equal("exit status 127"))
 		})
 	})

--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -251,6 +251,25 @@ func Warn(s string, v ...interface{}) {
 	_ = logger.logStdout.Output(1, message)
 }
 
+/*
+ * Progress is for messages that show progress as an alternative to a progress bar.
+ * We write them to the log file if fileVerbosity is >= LOGINFO, and we write them to stdout if shellVerbosity >= LOGVERBOSE
+ */
+
+func Progress(s string, v ...interface{}) {
+	logMutex.Lock()
+	defer logMutex.Unlock()
+	var message string
+	if logger.fileVerbosity >= LOGINFO {
+		message = GetLogPrefix("INFO") + fmt.Sprintf(s, v...)
+		_ = logger.logFile.Output(1, message)
+	}
+	if logger.shellVerbosity >= LOGVERBOSE {
+		message = GetLogPrefix("DEBUG") + fmt.Sprintf(s, v...)
+		_ = logger.logStdout.Output(1, message)
+	}
+}
+
 func Verbose(s string, v ...interface{}) {
 	logMutex.Lock()
 	defer logMutex.Unlock()

--- a/gplog/gplog_test.go
+++ b/gplog/gplog_test.go
@@ -177,6 +177,7 @@ var _ = Describe("logger/log tests", func() {
 		Describe("Shell verbosity set to Error", func() {
 			BeforeEach(func() {
 				gplog.SetVerbosity(gplog.LOGERROR)
+				gplog.SetLogFileVerbosity(gplog.LOGDEBUG)
 			})
 
 			Context("Info", func() {
@@ -195,6 +196,15 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "error progress"
+					gplog.Progress(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -240,6 +250,7 @@ var _ = Describe("logger/log tests", func() {
 		Describe("Shell verbosity set to Info", func() {
 			BeforeEach(func() {
 				gplog.SetVerbosity(gplog.LOGINFO)
+				gplog.SetLogFileVerbosity(gplog.LOGDEBUG)
 			})
 
 			Context("Info", func() {
@@ -258,6 +269,15 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "info progress"
+					gplog.Progress(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -303,6 +323,7 @@ var _ = Describe("logger/log tests", func() {
 		Describe("Shell verbosity set to Verbose", func() {
 			BeforeEach(func() {
 				gplog.SetVerbosity(gplog.LOGVERBOSE)
+				gplog.SetLogFileVerbosity(gplog.LOGDEBUG)
 			})
 
 			Context("Info", func() {
@@ -321,6 +342,15 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "verbose progress"
+					gplog.Progress(expectedMessage)
+					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -367,6 +397,7 @@ var _ = Describe("logger/log tests", func() {
 		Describe("Shell verbosity set to Debug", func() {
 			BeforeEach(func() {
 				gplog.SetVerbosity(gplog.LOGDEBUG)
+				gplog.SetLogFileVerbosity(gplog.LOGDEBUG)
 			})
 
 			Context("Info", func() {
@@ -385,6 +416,15 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug progress"
+					gplog.Progress(expectedMessage)
+					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -454,6 +494,15 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
 				})
 			})
+			Context("Progress", func() {
+				It("does not print", func() {
+					expectedMessage := "logfile error progress"
+					gplog.Progress(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
 			Context("Verbose", func() {
 				It("does not print", func() {
 					expectedMessage := "logfile error verbose"
@@ -497,6 +546,92 @@ var _ = Describe("logger/log tests", func() {
 				It("prints to the log file, then exit(1)", func() {
 					gplog.SetExitFunc(func() {})
 					expectedMessage := "logfile error fatalwithoutpanic"
+					gplog.FatalWithoutPanic(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, fatalExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, fatalExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, fatalExpected+expectedMessage)
+				})
+			})
+		})
+		Describe("Shell verbosity set to Info, logfile verbosity set to Info", func() {
+			BeforeEach(func() {
+				gplog.SetVerbosity(gplog.LOGINFO)
+				gplog.SetLogFileVerbosity(gplog.LOGINFO)
+			})
+			AfterEach(func() {
+				gplog.SetLogFileVerbosity(gplog.LOGDEBUG)
+			})
+
+			Context("Info", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "logfile info info"
+					gplog.Info(expectedMessage)
+					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
+			Context("Warn", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "logfile info warn"
+					gplog.Warn(expectedMessage)
+					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "logfile info progress"
+					gplog.Progress(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
+			Context("Verbose", func() {
+				It("does not print", func() {
+					expectedMessage := "logfile info verbose"
+					gplog.Verbose(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Debug", func() {
+				It("does not print", func() {
+					expectedMessage := "logfile info debug"
+					gplog.Debug(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, debugExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, debugExpected+expectedMessage)
+					testhelper.NotExpectRegexp(logfile, debugExpected+expectedMessage)
+				})
+			})
+			Context("Error", func() {
+				It("prints to stderr and the log file", func() {
+					expectedMessage := "logfile info error"
+					gplog.Error(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Fatal", func() {
+				It("prints to the log file, then panics", func() {
+					expectedMessage := "logfile info fatal"
+					defer func() {
+						testhelper.NotExpectRegexp(stdout, fatalExpected+expectedMessage)
+						testhelper.NotExpectRegexp(stderr, fatalExpected+expectedMessage)
+						testhelper.ExpectRegexp(logfile, fatalExpected+expectedMessage)
+					}()
+					defer testhelper.ShouldPanicWithMessage(expectedMessage)
+					gplog.Fatal(errors.New(expectedMessage), "")
+				})
+			})
+			Context("FatalWithoutPanic", func() {
+				It("prints to the log file, then exit(1)", func() {
+					gplog.SetExitFunc(func() {})
+					expectedMessage := "logfile info fatalwithoutpanic"
 					gplog.FatalWithoutPanic(expectedMessage)
 					testhelper.NotExpectRegexp(stdout, fatalExpected+expectedMessage)
 					testhelper.ExpectRegexp(stderr, fatalExpected+expectedMessage)


### PR DESCRIPTION
This is to be used with progress bars. It uses the prefix INFO and logs at
verbose level to stdout and info level to the log file so it won't disrupt
progress bars but will give useful information in the log files.