### PR TITLE
Added separate shell prefix and colorization to gplog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,7 @@ _testmain.go
 *.test
 *.prof
 
+# IntelliJ project metadata
+.idea/
+
 vendor

--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -105,8 +105,6 @@ type GpLogger struct {
 	shellVerbosity     int
 	fileVerbosity      int
 	header             string
-	shellHeader        string
-	fileHeader         string
 	logPrefixFunc      LogPrefixFunc
 	shellLogPrefixFunc LogPrefixFunc
 	colorize           bool

--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -215,6 +215,14 @@ func SetColorize(shouldColorize bool) {
 	logger.colorize = shouldColorize
 }
 
+// GetColorize returns whether the colorization of shell console output has been enabled
+func GetColorize() bool {
+	if logger == nil {
+		return false
+	}
+	return logger.colorize
+}
+
 func SetLogFileNameFunc(fileNameFunc func(string, string) string) {
 	logFileNameFunc = fileNameFunc
 }

--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -60,11 +60,14 @@ const (
 	LOGDEBUG
 )
 
-// --- constants for colorized output support
-const escape = "\x1b"
+// ESCAPE - ASCII escape character to start color character sequences
+const ESCAPE = "\x1b"
 
+type Color int
+
+// color codes in the order of their escape character sequences
 const (
-	NONE = iota
+	NONE Color = iota
 	RED
 	GREEN
 	YELLOW
@@ -482,17 +485,17 @@ func defaultExit() {
 }
 
 // color returns special characters that should be prepended to a string to make it of a particular color on the console
-func color(c int) string {
+func color(c Color) string {
 	if c == NONE {
-		return fmt.Sprintf("%s[%dm", escape, c)
+		return fmt.Sprintf("%s[%dm", ESCAPE, c)
 	}
-	return fmt.Sprintf("%s[3%dm", escape, c)
+	return fmt.Sprintf("%s[3%dm", ESCAPE, c)
 }
 
 // Colorize wraps a string with special characters so that the string has a provided color when output to the console
 // colorization happens only if the logger flag `colorize` is set to true. The function is exported to allow
 // colorization outside the logging methods, such as when recovering from a `panic` when Fatal messages are logged.
-func Colorize(c int, text string) string {
+func Colorize(c Color, text string) string {
 	if logger.colorize {
 		return color(c) + text + color(NONE)
 	}

--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -249,7 +249,7 @@ func GetLogPrefix(level string) string {
 // GetShellLogPrefix returns a prefix to prepend to the message before sending it to the shell console
 // Use this mechanism if it is desired to have different prefixes for messages sent to the console and to the log file.
 // A caller must first set a custom function that will provide a custom prefix by calling SetShellLogPrefixFunc.
-// If the custom function has not been provided, this function returns a prefix produced by the GelLogPrefix function,
+// If the custom function has not been provided, this function returns a prefix produced by the GetLogPrefix function,
 // so that the prefixes for the shell console and the log file will be the same.
 func GetShellLogPrefix(level string) string {
 	if logger.shellLogPrefixFunc != nil {

--- a/gplog/gplog_test.go
+++ b/gplog/gplog_test.go
@@ -741,6 +741,11 @@ var _ = Describe("logger/log tests", func() {
 				gplog.SetShellLogPrefixFunc(nil)
 			})
 
+			Context("Initialization", func() {
+				It("returns colorization info", func() {
+					Expect(gplog.GetColorize()).To(BeFalse())
+				})
+			})
 			Context("Info", func() {
 				It("prints to stdout and the log file", func() {
 					expectedMessage := "debug info"
@@ -838,6 +843,11 @@ var _ = Describe("logger/log tests", func() {
 				gplog.SetColorize(false)
 			})
 
+			Context("Initialization", func() {
+				It("returns colorization info", func() {
+					Expect(gplog.GetColorize()).To(BeTrue())
+				})
+			})
 			Context("Info", func() {
 				It("prints to stdout and the log file", func() {
 					expectedMessage := "debug info"

--- a/operating/operating.go
+++ b/operating/operating.go
@@ -57,6 +57,7 @@ func OpenFileWrite(name string, flag int, perm os.FileMode) (io.WriteCloser, err
 type SystemFunctions struct {
 	Chmod         func(name string, mode os.FileMode) error
 	CurrentUser   func() (*user.User, error)
+	Exit          func(code int)
 	Getenv        func(key string) string
 	Getpid        func() int
 	Glob          func(pattern string) (matches []string, err error)
@@ -80,6 +81,7 @@ func InitializeSystemFunctions() *SystemFunctions {
 	return &SystemFunctions{
 		Chmod:         os.Chmod,
 		CurrentUser:   user.Current,
+		Exit:          os.Exit,
 		Getenv:        os.Getenv,
 		Getpid:        os.Getpid,
 		Glob:          filepath.Glob,

--- a/operating/operating.go
+++ b/operating/operating.go
@@ -63,6 +63,7 @@ type SystemFunctions struct {
 	Glob          func(pattern string) (matches []string, err error)
 	Hostname      func() (string, error)
 	IsNotExist    func(err error) bool
+	LookupEnv     func(key string) (string, bool)
 	MkdirAll      func(path string, perm os.FileMode) error
 	Now           func() time.Time
 	OpenFileRead  func(name string, flag int, perm os.FileMode) (ReadCloserAt, error)
@@ -88,6 +89,7 @@ func InitializeSystemFunctions() *SystemFunctions {
 		Hostname:      os.Hostname,
 		IsNotExist:    os.IsNotExist,
 		MkdirAll:      os.MkdirAll,
+		LookupEnv:     os.LookupEnv,
 		Now:           time.Now,
 		OpenFileRead:  OpenFileRead,
 		OpenFileWrite: OpenFileWrite,


### PR DESCRIPTION
PXF uses `gplog` library to output to the console and log messages to the file, however we have the following requirements that are implemented by this PR. All existing functionality is intact, so the changes should be additive only.

1. Have separate prefixes for console and log file output. We do not want to have users see the "header" with timestamps, pids, etc as it pollutes the important message payloads. The prefixes are now separated and I included the default function that would only append logging level for WARNING, ERROR, and CRITICAL message levels.
2. We have colorized output to the console, so this functionality also has been added as a logger flag. When enbaled, the colorization will apply to ERROR and CRITICAL messages (red) , WARNING messages (yellow) and INFO messages logged with new `Success()` method only (green).
