### PR TITLE
Create Custom log command and use it for CheckClusterError

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -388,10 +388,10 @@ func (cluster *Cluster) CheckClusterError(remoteOutput *RemoteOutput, finalErrMs
 		case func(content int) string:
 			content := failedCommand.Content
 			host := cluster.GetHostForContent(content)
-			gplog.Verbose("%s on segment %d on host %s %s", getMessage(content), content, host, errStr)
+			gplog.Custom(gplog.LOGERROR, gplog.LOGVERBOSE, "%s on segment %d on host %s %s", getMessage(content), content, host, errStr)
 		case func(host string) string:
 			host := failedCommand.Host
-			gplog.Verbose("%s on host %s %s", getMessage(host), host, errStr)
+			gplog.Custom(gplog.LOGERROR, gplog.LOGVERBOSE, "%s on host %s %s", getMessage(host), host, errStr)
 		}
 		gplog.Verbose("Command was: %s", failedCommand.CommandString)
 	}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -559,7 +559,7 @@ var _ = Describe("cluster/cluster tests", func() {
 			}
 			defer testhelper.ShouldPanicWithMessage(fmt.Sprintf("Got an error on %s. See gbytes.Buffer for a complete list of errors.", errStr))
 			defer Expect(logfile).To(gbytes.Say(`\[DEBUG\]:-Command was: this is the command`))
-			defer Expect(logfile).To(gbytes.Say(fmt.Sprintf(`\[DEBUG\]:-Error received on %s with error command error: exit status 1`, debugStr)))
+			defer Expect(logfile).To(gbytes.Say(fmt.Sprintf(`\[ERROR\]:-Error received on %s with error command error: exit status 1`, debugStr)))
 			testCluster.CheckClusterError(remoteOutput, "Got an error", generatorFunc)
 		},
 			Entry("prints error messages for a per-segment command, including coordinator", cluster.ON_SEGMENTS|cluster.INCLUDE_COORDINATOR, true, true, true),

--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -430,15 +430,6 @@ func Custom(customFileVerbosity int, customShellVerbosity int, s string, v ...in
 	}
 }
 
-/*
- * Progress is a wrapper around the Custom logging function for messages that show progress as an alternative to a progress bar.
- * We write them to the log file if fileVerbosity is >= LOGINFO, and we write them to stdout if shellVerbosity >= LOGVERBOSE
- */
-
-func Progress(s string, v ...interface{}) {
-	Custom(LOGINFO, LOGVERBOSE, s, v...)
-}
-
 func FatalOnError(err error, output ...string) {
 	if err != nil {
 		if len(output) == 0 {

--- a/gplog/gplog_test.go
+++ b/gplog/gplog_test.go
@@ -311,15 +311,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
 				})
 			})
-			Context("Progress", func() {
-				It("prints to the log file", func() {
-					expectedMessage := "error progress"
-					gplog.Progress(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
-				})
-			})
 		})
 		Describe("Shell verbosity set to Info", func() {
 			BeforeEach(func() {
@@ -418,15 +409,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to the log file", func() {
-					expectedMessage := "info progress"
-					gplog.Progress(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 		})
@@ -530,15 +512,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
 				})
 			})
-			Context("Progress", func() {
-				It("prints to stdout and the log file", func() {
-					expectedMessage := "verbose progress"
-					gplog.Progress(expectedMessage)
-					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
-				})
-			})
 		})
 		Describe("Shell verbosity set to Debug", func() {
 			BeforeEach(func() {
@@ -637,15 +610,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to stdout and the log file", func() {
-					expectedMessage := "debug progress"
-					gplog.Progress(expectedMessage)
-					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 		})
@@ -761,15 +725,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
 				})
 			})
-			Context("Progress", func() {
-				It("does not print", func() {
-					expectedMessage := "logfile error progress"
-					gplog.Progress(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(logfile, infoExpected+expectedMessage)
-				})
-			})
 		})
 		Describe("Shell verbosity set to Info, logfile verbosity set to Info", func() {
 			BeforeEach(func() {
@@ -881,15 +836,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to the log file", func() {
-					expectedMessage := "logfile info progress"
-					gplog.Progress(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 		})
@@ -1010,16 +956,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to stdout and the log file", func() {
-					expectedMessage := "debug progress"
-					gplog.Progress(expectedMessage)
-					testhelper.ExpectRegexp(stdout, expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 		})
@@ -1146,16 +1082,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to stdout and the log file", func() {
-					expectedMessage := "debug progress"
-					gplog.Progress(expectedMessage)
-					testhelper.ExpectRegexp(stdout, expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 		})

--- a/gplog/gplog_test.go
+++ b/gplog/gplog_test.go
@@ -245,15 +245,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
 				})
 			})
-			Context("Progress", func() {
-				It("prints to the log file", func() {
-					expectedMessage := "error progress"
-					gplog.Progress(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
-				})
-			})
 			Context("Verbose", func() {
 				It("prints to the log file", func() {
 					expectedMessage := "error verbose"
@@ -293,6 +284,42 @@ var _ = Describe("logger/log tests", func() {
 					gplog.Fatal(errors.New(expectedMessage), "")
 				})
 			})
+			Context("Custom with shell as error and file as verbose", func() {
+				It("prints to stderr and the log file", func() {
+					expectedMessage := "error custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGERROR, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as verbose and file as verbose", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "error custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGVERBOSE, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as info and file as error", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "error custom"
+					gplog.Custom(gplog.LOGERROR, gplog.LOGINFO, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "error progress"
+					gplog.Progress(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
 		})
 		Describe("Shell verbosity set to Info", func() {
 			BeforeEach(func() {
@@ -325,15 +352,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to the log file", func() {
-					expectedMessage := "info progress"
-					gplog.Progress(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -375,6 +393,42 @@ var _ = Describe("logger/log tests", func() {
 					gplog.Fatal(errors.New(expectedMessage), "")
 				})
 			})
+			Context("Custom with shell as error and file as verbose", func() {
+				It("prints to stderr and the log file", func() {
+					expectedMessage := "info custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGERROR, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as verbose and file as verbose", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "info custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGVERBOSE, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as info and file as error", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "info custom"
+					gplog.Custom(gplog.LOGERROR, gplog.LOGINFO, expectedMessage)
+					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "info progress"
+					gplog.Progress(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
 		})
 		Describe("Shell verbosity set to Verbose", func() {
 			BeforeEach(func() {
@@ -407,15 +461,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to stdout and the log file", func() {
-					expectedMessage := "verbose progress"
-					gplog.Progress(expectedMessage)
-					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -458,6 +503,42 @@ var _ = Describe("logger/log tests", func() {
 					gplog.Fatal(errors.New(expectedMessage), "")
 				})
 			})
+			Context("Custom with shell as error and file as verbose", func() {
+				It("prints to stderr and the log file", func() {
+					expectedMessage := "verbose custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGERROR, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as verbose and file as verbose", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "verbose custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGVERBOSE, expectedMessage)
+					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as info and file as error", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "verbose custom"
+					gplog.Custom(gplog.LOGERROR, gplog.LOGINFO, expectedMessage)
+					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "verbose progress"
+					gplog.Progress(expectedMessage)
+					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
 		})
 		Describe("Shell verbosity set to Debug", func() {
 			BeforeEach(func() {
@@ -490,15 +571,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to stdout and the log file", func() {
-					expectedMessage := "debug progress"
-					gplog.Progress(expectedMessage)
-					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -540,6 +612,42 @@ var _ = Describe("logger/log tests", func() {
 					gplog.Fatal(errors.New(expectedMessage), "")
 				})
 			})
+			Context("Custom with shell as error and file as verbose", func() {
+				It("prints to stderr and the log file", func() {
+					expectedMessage := "debug custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGERROR, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as verbose and file as verbose", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGVERBOSE, expectedMessage)
+					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as info and file as error", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug custom"
+					gplog.Custom(gplog.LOGERROR, gplog.LOGINFO, expectedMessage)
+					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug progress"
+					gplog.Progress(expectedMessage)
+					testhelper.ExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
 		})
 		Describe("Shell verbosity set to Info, logfile verbosity set to Error", func() {
 			BeforeEach(func() {
@@ -575,15 +683,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("does not print", func() {
-					expectedMessage := "logfile error progress"
-					gplog.Progress(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -635,6 +734,42 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(logfile, fatalExpected+expectedMessage)
 				})
 			})
+			Context("Custom with shell as error and file as verbose", func() {
+				It("prints to stderr", func() {
+					expectedMessage := "logfile error custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGERROR, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.NotExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as verbose and file as verbose", func() {
+				It("does not print", func() {
+					expectedMessage := "logfile error custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGVERBOSE, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as info and file as error", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "info custom"
+					gplog.Custom(gplog.LOGERROR, gplog.LOGINFO, expectedMessage)
+					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("does not print", func() {
+					expectedMessage := "logfile error progress"
+					gplog.Progress(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
 		})
 		Describe("Shell verbosity set to Info, logfile verbosity set to Info", func() {
 			BeforeEach(func() {
@@ -670,15 +805,6 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to the log file", func() {
-					expectedMessage := "logfile info progress"
-					gplog.Progress(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -730,6 +856,42 @@ var _ = Describe("logger/log tests", func() {
 					testhelper.ExpectRegexp(logfile, fatalExpected+expectedMessage)
 				})
 			})
+			Context("Custom with shell as error and file as verbose", func() {
+				It("prints to stderr", func() {
+					expectedMessage := "logfile info custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGERROR, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.NotExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as verbose and file as verbose", func() {
+				It("does not print", func() {
+					expectedMessage := "logfile info custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGVERBOSE, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as info and file as error", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "info custom"
+					gplog.Custom(gplog.LOGERROR, gplog.LOGINFO, expectedMessage)
+					testhelper.ExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to the log file", func() {
+					expectedMessage := "logfile info progress"
+					gplog.Progress(expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
+				})
+			})
 		})
 		Describe("Custom Shell Prefix used - shell verbosity set to Debug", func() {
 			BeforeEach(func() {
@@ -751,8 +913,8 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug info"
 					gplog.Info(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
@@ -761,8 +923,8 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug info"
 					gplog.Success(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
@@ -771,19 +933,9 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug warn"
 					gplog.Warn(expectedMessage)
 					testhelper.ExpectRegexp(stdout, "WARNING: "+expectedMessage)
+					testhelper.NotExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, "WARNING: "+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to stdout and the log file", func() {
-					expectedMessage := "debug progress"
-					gplog.Progress(expectedMessage)
-					testhelper.ExpectRegexp(stdout, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -791,8 +943,8 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug verbose"
 					gplog.Verbose(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
 				})
 			})
@@ -801,8 +953,8 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug debug"
 					gplog.Debug(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, debugExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, debugExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, debugExpected+expectedMessage)
 				})
 			})
@@ -810,9 +962,9 @@ var _ = Describe("logger/log tests", func() {
 				It("prints to stderr and the log file", func() {
 					expectedMessage := "debug error"
 					gplog.Error(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, "ERROR: "+expectedMessage)
-					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stdout, expectedMessage)
 					testhelper.ExpectRegexp(stderr, "ERROR: "+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, errorExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
 				})
 			})
@@ -828,6 +980,46 @@ var _ = Describe("logger/log tests", func() {
 					}()
 					defer testhelper.ShouldPanicWithMessage("CRITICAL: " + expectedMessage)
 					gplog.Fatal(errors.New(expectedMessage), "")
+				})
+			})
+			Context("Custom with shell as error and file as verbose", func() {
+				It("prints to stderr and the log file", func() {
+					expectedMessage := "debug custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGERROR, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, expectedMessage)
+					testhelper.ExpectRegexp(stderr, "ERROR: "+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as verbose and file as verbose", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGVERBOSE, expectedMessage)
+					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as info and file as error", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug custom"
+					gplog.Custom(gplog.LOGERROR, gplog.LOGINFO, expectedMessage)
+					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug progress"
+					gplog.Progress(expectedMessage)
+					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 		})
@@ -853,8 +1045,8 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug info"
 					gplog.Info(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
@@ -864,8 +1056,8 @@ var _ = Describe("logger/log tests", func() {
 					expectedConsoleMessage := fmt.Sprintf("%[1]s[32mdebug success%[1]s[0m", "\x1b")
 					gplog.Success(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedConsoleMessage)
-					testhelper.NotExpectRegexp(stderr, "INFO: "+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, expectedMessage)
 					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
@@ -875,19 +1067,9 @@ var _ = Describe("logger/log tests", func() {
 					expectedConsoleMessage := fmt.Sprintf("%[1]s[33mWARNING: debug warn%[1]s[0m", "\x1b")
 					gplog.Warn(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedConsoleMessage)
-					testhelper.NotExpectRegexp(stderr, "WARNING: "+expectedMessage)
-					testhelper.NotExpectRegexp(stderr, warnExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
-				})
-			})
-			Context("Progress", func() {
-				It("prints to stdout and the log file", func() {
-					expectedMessage := "debug progress"
-					gplog.Progress(expectedMessage)
-					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, warnExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
-					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, warnExpected+expectedMessage)
 				})
 			})
 			Context("Verbose", func() {
@@ -895,8 +1077,8 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug verbose"
 					gplog.Verbose(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, verboseExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
 				})
 			})
@@ -905,8 +1087,8 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug debug"
 					gplog.Debug(expectedMessage)
 					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, debugExpected+expectedMessage)
 					testhelper.NotExpectRegexp(stderr, expectedMessage)
-					testhelper.NotExpectRegexp(stderr, debugExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, debugExpected+expectedMessage)
 				})
 			})
@@ -915,9 +1097,9 @@ var _ = Describe("logger/log tests", func() {
 					expectedMessage := "debug error"
 					expectedConsoleMessage := fmt.Sprintf("%[1]s[31mERROR: debug error%[1]s[0m", "\x1b")
 					gplog.Error(expectedMessage)
-					testhelper.NotExpectRegexp(stdout, "ERROR: "+expectedMessage)
-					testhelper.NotExpectRegexp(stdout, errorExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stdout, expectedMessage)
 					testhelper.ExpectRegexp(stderr, expectedConsoleMessage)
+					testhelper.NotExpectRegexp(stderr, errorExpected+expectedMessage)
 					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
 				})
 			})
@@ -933,6 +1115,47 @@ var _ = Describe("logger/log tests", func() {
 					}()
 					defer testhelper.ShouldPanicWithMessage("CRITICAL: " + expectedMessage)
 					gplog.Fatal(errors.New(expectedMessage), "")
+				})
+			})
+			Context("Custom with shell as error and file as verbose", func() {
+				It("prints to stderr and the log file", func() {
+					expectedMessage := "debug custom"
+					expectedConsoleMessage := fmt.Sprintf("%[1]s[31mERROR: debug custom%[1]s[0m", "\x1b")
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGERROR, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, expectedMessage)
+					testhelper.ExpectRegexp(stderr, expectedConsoleMessage)
+					testhelper.NotExpectRegexp(stderr, errorExpected+expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as verbose and file as verbose", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug custom"
+					gplog.Custom(gplog.LOGVERBOSE, gplog.LOGVERBOSE, expectedMessage)
+					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, expectedMessage)
+					testhelper.ExpectRegexp(logfile, verboseExpected+expectedMessage)
+				})
+			})
+			Context("Custom with shell as info and file as error", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug custom"
+					gplog.Custom(gplog.LOGERROR, gplog.LOGINFO, expectedMessage)
+					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, infoExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, expectedMessage)
+					testhelper.ExpectRegexp(logfile, errorExpected+expectedMessage)
+				})
+			})
+			Context("Progress", func() {
+				It("prints to stdout and the log file", func() {
+					expectedMessage := "debug progress"
+					gplog.Progress(expectedMessage)
+					testhelper.ExpectRegexp(stdout, expectedMessage)
+					testhelper.NotExpectRegexp(stdout, verboseExpected+expectedMessage)
+					testhelper.NotExpectRegexp(stderr, expectedMessage)
+					testhelper.ExpectRegexp(logfile, infoExpected+expectedMessage)
 				})
 			})
 		})


### PR DESCRIPTION
Replace Progress command with Custom command for more logging control.

The Progress command was just for doing info level to the logfile and verbose
level to stdout for table progress in gpbackup and gprestore. However, I found
at least one more place where using different settings for terminal and logfile
would be useful. We CheckClusterError in the cluster package for some commands
and assume we will log details to the file, but not to stdout.

Since this is a more general use case, we can make a more general command that
lets the caller pass in values for file threshold and shell threshold
separately to accommodate more use cases.

Then we can use the new command for CheckClusterError to maintain the usual behavior
of always writing errors to the log file but only writing to the shell if the level is verbose or higher.