### PR TITLE
Add length check on segmentList to avoid panic

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -435,6 +435,9 @@ func getSegmentByRole(segmentList []*SegConfig, role ...string) *SegConfig {
 		}
 		return segmentList[1]
 	}
+	if len(segmentList) == 0 {
+		return nil
+	}
 	return segmentList[0]
 }
 


### PR DESCRIPTION
This PR adds a length check on the `segmentList` within `getSegmentByRole()` before returning the first index to avoid panicking.