### PR TITLE
Log out  err.Detail if the type of err is PgError

### DIFF
--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/jackc/pgconn"
 	"github.com/pkg/errors"
 )
 
@@ -390,7 +391,12 @@ func Fatal(err error, s string, v ...interface{}) {
 	message := ""
 	stackTraceStr := ""
 	if err != nil {
-		message += fmt.Sprintf("%v", err)
+		if _, ok := err.(*pgconn.PgError); ok {
+			message += fmt.Sprintf("%v", err)
+		} else {
+			message += fmt.Sprintf("%v; ", err.(*pgconn.PgError).Message)
+			message += fmt.Sprintf("%v ", err.(*pgconn.PgError).Detail)
+		}
 		stackTraceStr = formatStackTrace(errors.WithStack(err))
 		if s != "" {
 			message += ": "

--- a/gplog/gplog.go
+++ b/gplog/gplog.go
@@ -391,7 +391,7 @@ func Fatal(err error, s string, v ...interface{}) {
 	message := ""
 	stackTraceStr := ""
 	if err != nil {
-		if _, ok := err.(*pgconn.PgError); ok {
+		if _, ok := err.(*pgconn.PgError); !ok {
 			message += fmt.Sprintf("%v", err)
 		} else {
 			message += fmt.Sprintf("%v; ", err.(*pgconn.PgError).Message)


### PR DESCRIPTION
Long log:

After improvements to COPY error handling, some _errmsg_ got moved to _errdetail_ in [GPDB pr 17583](https://github.com/greenplum-db/gpdb/pull/17583). 
Take a known bug in gpcopy to illustrate the problem.
The gpcopy log without this PR-17583：
```
ERROR: command error message: 20240524:10:44:46 gpcopy_helper:gpadmin:gpdb7x-src:032189-[ERROR]:-Error: dialing to [fc00:f853:ccd:e793::1]:15925 time out: dial tcp [fc00:f853:ccd:e793::1]:15925: connect: network is unreachable
```
The gpcopy log with this PR-17583：
```
ERROR: child process exited with exit code 1  (seg1 [10.121.163.5:15435](http://10.121.163.5:15435/) pid=3502) (SQLSTATE 38000)
```
Then our users must check the gpdb log to find more details. 
To locate the problem by log more quickly, we decided to let **gp-common-go-libs** not only print out the Error.**Message**, but also Error.**Detail**.

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>
Co-authored-by: Wenkang Zhang <wenkang.zhang@broadcom.com>